### PR TITLE
More generic read/write api

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,7 @@ where
         }
 
         let mut pipe = Pipe {
-            reader: &mut Box::new(reader),
+            reader,
             buffer: &mut [0; READER_BUFFER_SIZE],
         };
 


### PR DESCRIPTION
Require just `Read` and `Write` for input arguments and drop the `'static` requirement for `Read`.

This allows, for one, the use of slices as write targets for `uncompress_file`, a (doc) test as been added for it to avoid regression bugs.

This should not be a breaking change since we have that `impl<'_, W: Write + ?Sized> Write for &'_ mut W` and `impl<'_, R: Read + ?Sized> Read for &'_ mut R`.