### PR TITLE
Fix opening target files in read-only mode

### DIFF
--- a/examples/uncompress.rs
+++ b/examples/uncompress.rs
@@ -91,13 +91,13 @@ fn main() -> compress_tools::Result<()> {
 
         CmdLine::UncompressData(input) => {
             let mut source = std::fs::File::open(input.source_path)?;
-            let mut target = std::fs::File::open(input.target_path)?;
+            let mut target = std::fs::File::create(input.target_path)?;
 
             uncompress_data(&mut source, &mut target)?;
         }
         CmdLine::UncompressArchiveFile(input) => {
             let mut source = std::fs::File::open(input.source_path)?;
-            let mut target = std::fs::File::open(input.target_path)?;
+            let mut target = std::fs::File::create(input.target_path)?;
 
             uncompress_archive_file(&mut source, &mut target, &input.target_file)?;
         }


### PR DESCRIPTION
Currently, running `cargo run --example uncompress uncompress-data log.gz log` produces the following output:

```
Error: Io(Os { code: 2, kind: NotFound, message: "No such file or directory" })
```

From documentation of the `File::open`:

> Attempts to open a file in **read-only** mode.

This is undesirable for a file that is supposed to be written to.