### PR TITLE
Add Tokio support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-* Uncompress service example
+* Optional async support
+* Uncompress service example and its async-std and Tokio counterparts
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,11 @@ vcpkg = "0.2"
 
 [target.'cfg(not(target_os = "windows"))'.build-dependencies]
 pkg-config = "0.3"
+
+[[example]]
+name = "uncompress_service_futures"
+required-features = ["futures_support"]
+
+[[example]]
+name = "uncompress_service_tokio"
+required-features = ["tokio_support"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,15 @@ coveralls = { repository = "ossystems/compress-tools-rs" }
 
 [dependencies]
 derive_more = { version = "0.99", default-features = false, features = ["display", "from", "error"] }
+async-trait = { version = "0.1.39", optional = true }
+futures-channel = { version = "0.3.5", features = ["sink"], optional = true }
+futures-core = { version = "0.3.5", optional = true }
+futures-io = { version = "0.3.5", optional = true }
+futures-util = { version = "0.3.5", features = ["sink", "io"], optional = true }
+futures-executor = { version = "0.3.5", optional = true }
+
+[features]
+async_support = ["async-trait", "futures-channel", "futures-core", "futures-io", "futures-util", "futures-executor"]
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,16 @@ futures-core = { version = "0.3.5", optional = true }
 futures-io = { version = "0.3.5", optional = true }
 futures-util = { version = "0.3.5", features = ["sink", "io"], optional = true }
 futures-executor = { version = "0.3.5", optional = true }
+blocking = { version = "0.6.1", optional = true }
 
 [features]
 async_support = ["async-trait", "futures-channel", "futures-core", "futures-io", "futures-util", "futures-executor"]
+futures_support = ["async_support", "blocking"]
 
 [dev-dependencies]
 tempfile = "3.1"
 argh = "0.1"
+async-std = { version = "1.6.3", features = ["attributes"] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 vcpkg = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,19 @@ futures-io = { version = "0.3.5", optional = true }
 futures-util = { version = "0.3.5", features = ["sink", "io"], optional = true }
 futures-executor = { version = "0.3.5", optional = true }
 blocking = { version = "0.6.1", optional = true }
+tokio = { version = "0.2.22", features = ["blocking", "macros"], optional = true }
+tokio-util = { version = "0.3.1", features = ["compat"], optional = true }
 
 [features]
 async_support = ["async-trait", "futures-channel", "futures-core", "futures-io", "futures-util", "futures-executor"]
 futures_support = ["async_support", "blocking"]
+tokio_support = ["async_support", "tokio", "tokio-util"]
 
 [dev-dependencies]
 tempfile = "3.1"
 argh = "0.1"
 async-std = { version = "1.6.3", features = ["attributes"] }
+tokio = { version = "0.2.22", features = ["fs", "net"] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 vcpkg = "0.2"

--- a/examples/uncompress_service_futures.rs
+++ b/examples/uncompress_service_futures.rs
@@ -1,0 +1,23 @@
+// Copyright (C) 2019, 2020 O.S. Systems Sofware LTDA
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use async_std::net::TcpListener;
+use compress_tools::futures_support::uncompress_data;
+
+/// Example usage:
+/// ```
+/// $ ncat localhost 1234 < tests/fixtures/file.txt.gz
+/// some_file_content
+/// ```
+
+#[async_std::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let listener = TcpListener::bind("127.0.0.1:1234").await?;
+    loop {
+        let (socket, _) = listener.accept().await?;
+        async_std::task::spawn(async move {
+            println!("{:?}", uncompress_data(&socket, &socket).await);
+        });
+    }
+}

--- a/examples/uncompress_service_tokio.rs
+++ b/examples/uncompress_service_tokio.rs
@@ -1,0 +1,24 @@
+// Copyright (C) 2019, 2020 O.S. Systems Sofware LTDA
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use compress_tools::tokio_support::uncompress_data;
+use tokio::net::TcpListener;
+
+/// Example usage:
+/// ```
+/// $ ncat localhost 1234 < tests/fixtures/file.txt.gz
+/// some_file_content
+/// ```
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut listener = TcpListener::bind("127.0.0.1:1234").await?;
+    loop {
+        let (socket, _) = listener.accept().await?;
+        tokio::spawn(async move {
+            let (read_half, write_half) = socket.into_split();
+            println!("{:?}", uncompress_data(read_half, write_half).await);
+        });
+    }
+}

--- a/src/async_support.rs
+++ b/src/async_support.rs
@@ -1,0 +1,202 @@
+// Copyright (C) 2019, 2020 O.S. Systems Sofware LTDA
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Generic async support with which you can use you own thread pool by
+//! implementing the [`BlockingExecutor`] trait.
+
+use crate::{Ownership, Result, READER_BUFFER_SIZE};
+use async_trait::async_trait;
+use futures_channel::mpsc::{channel, Receiver, Sender};
+use futures_core::FusedStream;
+use futures_executor::block_on;
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    join,
+    sink::SinkExt,
+    stream::StreamExt,
+};
+use std::{
+    future::Future,
+    io::{ErrorKind, Read, Write},
+    path::Path,
+};
+
+#[async_trait]
+pub trait BlockingExecutor {
+    /// Execute the provided function on a thread where blocking is acceptable
+    /// (in some kind of thread pool).
+    async fn execute_blocking<T, F>(f: F) -> Result<T>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> T + Send + 'static;
+}
+
+struct AsyncReadWrapper {
+    rx: Receiver<Vec<u8>>,
+}
+
+impl Read for AsyncReadWrapper {
+    fn read(&mut self, mut buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.rx.is_terminated() {
+            return Ok(0);
+        }
+        assert_eq!(buf.len(), READER_BUFFER_SIZE);
+        Ok(match block_on(self.rx.next()) {
+            Some(data) => {
+                buf.write_all(&data)?;
+                data.len()
+            }
+            None => 0,
+        })
+    }
+}
+
+fn make_async_read_wrapper_and_worker<R>(
+    mut read: R,
+) -> (AsyncReadWrapper, impl Future<Output = Result<()>>)
+where
+    R: AsyncRead + Unpin,
+{
+    let (mut tx, rx) = channel(0);
+    (AsyncReadWrapper { rx }, async move {
+        loop {
+            let mut data = vec![0; READER_BUFFER_SIZE];
+            let read = read.read(&mut data).await?;
+            data.truncate(read);
+            if read == 0 || tx.send(data).await.is_err() {
+                break;
+            }
+        }
+        Ok(())
+    })
+}
+
+struct AsyncWriteWrapper {
+    tx: Sender<Vec<u8>>,
+}
+
+impl Write for AsyncWriteWrapper {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match block_on(self.tx.send(buf.to_owned())) {
+            Ok(()) => Ok(buf.len()),
+            Err(err) => Err(std::io::Error::new(ErrorKind::Other, err)),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        block_on(self.tx.send(vec![])).map_err(|err| std::io::Error::new(ErrorKind::Other, err))
+    }
+}
+
+fn make_async_write_wrapper_and_worker<W>(
+    mut write: W,
+) -> (AsyncWriteWrapper, impl Future<Output = Result<()>>)
+where
+    W: AsyncWrite + Unpin,
+{
+    let (tx, mut rx) = channel(0);
+    (AsyncWriteWrapper { tx }, async move {
+        while let Some(v) = rx.next().await {
+            if v.is_empty() {
+                write.flush().await?;
+            } else {
+                write.write_all(&v).await?;
+            }
+        }
+        Ok(())
+    })
+}
+
+async fn wrap_async_read<B, R, F, T>(_: B, read: R, f: F) -> Result<T>
+where
+    B: BlockingExecutor,
+    R: AsyncRead + Unpin,
+    F: FnOnce(AsyncReadWrapper) -> T + Send + 'static,
+    T: Send + 'static,
+{
+    let (async_read_wrapper, async_read_wrapper_worker) = make_async_read_wrapper_and_worker(read);
+    let g = B::execute_blocking(move || f(async_read_wrapper));
+    let join = join!(async_read_wrapper_worker, g);
+    join.0?;
+    join.1
+}
+
+async fn wrap_async_read_and_write<B, R, W, F, T>(_: B, read: R, write: W, f: F) -> Result<T>
+where
+    B: BlockingExecutor,
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+    F: FnOnce(AsyncReadWrapper, AsyncWriteWrapper) -> T + Send + 'static,
+    T: Send + 'static,
+{
+    let (async_read_wrapper, async_read_wrapper_worker) = make_async_read_wrapper_and_worker(read);
+    let (async_write_wrapper, async_write_wrapper_worker) =
+        make_async_write_wrapper_and_worker(write);
+    let g = B::execute_blocking(move || f(async_read_wrapper, async_write_wrapper));
+    let join = join!(async_read_wrapper_worker, async_write_wrapper_worker, g);
+    join.0?;
+    join.1?;
+    join.2
+}
+
+/// Async version of [`list_archive_files`](crate::list_archive_files).
+pub async fn list_archive_files<B, R>(blocking_executor: B, source: R) -> Result<Vec<String>>
+where
+    B: BlockingExecutor,
+    R: AsyncRead + Unpin,
+{
+    wrap_async_read(blocking_executor, source, crate::list_archive_files).await?
+}
+
+/// Async version of [`uncompress_data`](crate::uncompress_data).
+pub async fn uncompress_data<B, R, W>(blocking_executor: B, source: R, target: W) -> Result<usize>
+where
+    B: BlockingExecutor,
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    wrap_async_read_and_write(blocking_executor, source, target, |source, target| {
+        crate::uncompress_data(source, target)
+    })
+    .await?
+}
+
+/// Async version of [`uncompress_archive`](crate::uncompress_archive).
+pub async fn uncompress_archive<B, R>(
+    blocking_executor: B,
+    source: R,
+    dest: &Path,
+    ownership: Ownership,
+) -> Result<()>
+where
+    B: BlockingExecutor,
+    R: AsyncRead + Unpin,
+{
+    let dest = dest.to_owned();
+    wrap_async_read(blocking_executor, source, move |source| {
+        crate::uncompress_archive(source, &dest, ownership)
+    })
+    .await?
+}
+
+/// Async version of
+/// [`uncompress_archive_file`](crate::uncompress_archive_file).
+pub async fn uncompress_archive_file<B, R, W>(
+    blocking_executor: B,
+    source: R,
+    target: W,
+    path: &str,
+) -> Result<usize>
+where
+    B: BlockingExecutor,
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let path = path.to_owned();
+    wrap_async_read_and_write(blocking_executor, source, target, move |source, target| {
+        crate::uncompress_archive_file(source, target, &path)
+    })
+    .await?
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,10 @@ pub enum Error {
     #[display(transparent)]
     Utf(std::str::Utf8Error),
 
+    #[cfg(feature = "tokio_support")]
+    #[display(transparent)]
+    JoinError(tokio::task::JoinError),
+
     #[display(fmt = "Error to create the archive struct, is null")]
     NullArchive,
 

--- a/src/futures_support.rs
+++ b/src/futures_support.rs
@@ -1,0 +1,56 @@
+//! Async support with a built-in thread pool.
+
+use crate::{async_support, async_support::BlockingExecutor, Ownership, Result};
+use async_trait::async_trait;
+use futures_io::{AsyncRead, AsyncWrite};
+use std::path::Path;
+
+struct FuturesBlockingExecutor {}
+
+#[async_trait]
+impl BlockingExecutor for FuturesBlockingExecutor {
+    async fn execute_blocking<T, F>(f: F) -> Result<T>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> T + Send + 'static,
+    {
+        Ok(blocking::unblock(f).await)
+    }
+}
+
+const FUTURES_BLOCKING_EXECUTOR: FuturesBlockingExecutor = FuturesBlockingExecutor {};
+
+/// Async version of [`list_archive_files`](crate::list_archive_files).
+pub async fn list_archive_files<R>(source: R) -> Result<Vec<String>>
+where
+    R: AsyncRead + Unpin,
+{
+    async_support::list_archive_files(FUTURES_BLOCKING_EXECUTOR, source).await
+}
+
+/// Async version of [`uncompress_data`](crate::uncompress_data).
+pub async fn uncompress_data<R, W>(source: R, target: W) -> Result<usize>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    async_support::uncompress_data(FUTURES_BLOCKING_EXECUTOR, source, target).await
+}
+
+/// Async version of [`uncompress_archive`](crate::uncompress_archive).
+pub async fn uncompress_archive<R>(source: R, dest: &Path, ownership: Ownership) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+{
+    async_support::uncompress_archive(FUTURES_BLOCKING_EXECUTOR, source, dest, ownership).await
+}
+
+/// Async version of
+/// [`uncompress_archive_file`](crate::uncompress_archive_file).
+pub async fn uncompress_archive_file<R, W>(source: R, target: W, path: &str) -> Result<usize>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    async_support::uncompress_archive_file(FUTURES_BLOCKING_EXECUTOR, source, target, path).await
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,8 @@
 pub mod async_support;
 mod error;
 mod ffi;
+#[cfg(feature = "futures_support")]
+pub mod futures_support;
 
 use error::archive_result;
 pub use error::{Error, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,8 @@ mod error;
 mod ffi;
 #[cfg(feature = "futures_support")]
 pub mod futures_support;
+#[cfg(feature = "tokio_support")]
+pub mod tokio_support;
 
 use error::archive_result;
 pub use error::{Error, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@
 //! # }
 //! ```
 
+#[cfg(feature = "async_support")]
+pub mod async_support;
 mod error;
 mod ffi;
 
@@ -148,7 +150,7 @@ where
 /// use std::fs::File;
 ///
 /// let mut source = File::open("file.txt.gz")?;
-/// let mut target = [0 as u8;313];
+/// let mut target = [0 as u8; 313];
 ///
 /// uncompress_data(&mut source, &mut target as &mut [u8])?;
 /// # Ok(())

--- a/src/tokio_support.rs
+++ b/src/tokio_support.rs
@@ -1,0 +1,69 @@
+//! Async support that uses [`tokio::task::spawn_blocking`] and its I/O traits.
+
+use crate::{async_support, async_support::BlockingExecutor, Ownership, Result};
+use async_trait::async_trait;
+use std::path::Path;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_util::compat::{Tokio02AsyncReadCompatExt, Tokio02AsyncWriteCompatExt};
+
+struct TokioBlockingExecutor {}
+
+#[async_trait]
+impl BlockingExecutor for TokioBlockingExecutor {
+    async fn execute_blocking<T, F>(f: F) -> Result<T>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> T + Send + 'static,
+    {
+        tokio::task::spawn_blocking(f).await.map_err(Into::into)
+    }
+}
+
+const TOKIO_BLOCKING_EXECUTOR: TokioBlockingExecutor = TokioBlockingExecutor {};
+
+/// Async version of [`list_archive_files`](crate::list_archive_files).
+pub async fn list_archive_files<R>(source: R) -> Result<Vec<String>>
+where
+    R: AsyncRead + Unpin,
+{
+    async_support::list_archive_files(TOKIO_BLOCKING_EXECUTOR, source.compat()).await
+}
+
+/// Async version of [`uncompress_data`](crate::uncompress_data).
+pub async fn uncompress_data<R, W>(source: R, target: W) -> Result<usize>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    async_support::uncompress_data(
+        TOKIO_BLOCKING_EXECUTOR,
+        source.compat(),
+        target.compat_write(),
+    )
+    .await
+}
+
+/// Async version of [`uncompress_archive`](crate::uncompress_archive).
+pub async fn uncompress_archive<R>(source: R, dest: &Path, ownership: Ownership) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+{
+    async_support::uncompress_archive(TOKIO_BLOCKING_EXECUTOR, source.compat(), dest, ownership)
+        .await
+}
+
+/// Async version of
+/// [`uncompress_archive_file`](crate::uncompress_archive_file).
+pub async fn uncompress_archive_file<R, W>(source: R, target: W, path: &str) -> Result<usize>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    async_support::uncompress_archive_file(
+        TOKIO_BLOCKING_EXECUTOR,
+        source.compat(),
+        target.compat_write(),
+        path,
+    )
+    .await
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18,6 +18,44 @@ fn get_compressed_file_content() {
     assert_eq!(written, 18, "Uncompressed bytes count did not match");
 }
 
+#[async_std::test]
+#[cfg(feature = "futures_support")]
+async fn get_compressed_file_content_futures() {
+    let mut source = async_std::fs::File::open("tests/fixtures/file.txt.gz")
+        .await
+        .unwrap();
+    let mut target = Vec::default();
+
+    let written = futures_support::uncompress_data(&mut source, &mut target)
+        .await
+        .expect("Failed to uncompress the file");
+    assert_eq!(
+        String::from_utf8_lossy(&target),
+        "some_file_content\n",
+        "Uncompressed file did not match",
+    );
+    assert_eq!(written, 18, "Uncompressed bytes count did not match");
+}
+
+#[tokio::test]
+#[cfg(feature = "tokio_support")]
+async fn get_compressed_file_content_tokio() {
+    let mut source = tokio::fs::File::open("tests/fixtures/file.txt.gz")
+        .await
+        .unwrap();
+    let mut target = Vec::default();
+
+    let written = tokio_support::uncompress_data(&mut source, &mut target)
+        .await
+        .expect("Failed to uncompress the file");
+    assert_eq!(
+        String::from_utf8_lossy(&target),
+        "some_file_content\n",
+        "Uncompressed file did not match",
+    );
+    assert_eq!(written, 18, "Uncompressed bytes count did not match");
+}
+
 #[test]
 fn get_a_file_from_tar() {
     let mut source = std::fs::File::open("tests/fixtures/tree.tar").unwrap();
@@ -33,12 +71,92 @@ fn get_a_file_from_tar() {
     assert_eq!(written, 14, "Uncompressed bytes count did not match");
 }
 
+#[async_std::test]
+#[cfg(feature = "futures_support")]
+async fn get_a_file_from_tar_futures() {
+    let mut source = async_std::fs::File::open("tests/fixtures/tree.tar")
+        .await
+        .unwrap();
+    let mut target = Vec::default();
+
+    let written =
+        futures_support::uncompress_archive_file(&mut source, &mut target, &"tree/branch2/leaf")
+            .await
+            .expect("Failed to get the file");
+    assert_eq!(
+        String::from_utf8_lossy(&target),
+        "Goodbye World\n",
+        "Uncompressed file did not match",
+    );
+    assert_eq!(written, 14, "Uncompressed bytes count did not match");
+}
+
+#[tokio::test]
+#[cfg(feature = "tokio_support")]
+async fn get_a_file_from_tar_tokio() {
+    let mut source = tokio::fs::File::open("tests/fixtures/tree.tar")
+        .await
+        .unwrap();
+    let mut target = Vec::default();
+
+    let written =
+        tokio_support::uncompress_archive_file(&mut source, &mut target, &"tree/branch2/leaf")
+            .await
+            .expect("Failed to get the file");
+    assert_eq!(
+        String::from_utf8_lossy(&target),
+        "Goodbye World\n",
+        "Uncompressed file did not match",
+    );
+    assert_eq!(written, 14, "Uncompressed bytes count did not match");
+}
+
 #[test]
 fn successfully_list_archive_files() {
     let source = std::fs::File::open("tests/fixtures/tree.tar").unwrap();
 
     assert_eq!(
         list_archive_files(source).unwrap(),
+        vec![
+            "tree/".to_string(),
+            "tree/branch1/".to_string(),
+            "tree/branch1/leaf".to_string(),
+            "tree/branch2/".to_string(),
+            "tree/branch2/leaf".to_string(),
+        ],
+        "file list inside the archive did not match"
+    );
+}
+
+#[async_std::test]
+#[cfg(feature = "futures_support")]
+async fn successfully_list_archive_files_futures() {
+    let source = async_std::fs::File::open("tests/fixtures/tree.tar")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        futures_support::list_archive_files(source).await.unwrap(),
+        vec![
+            "tree/".to_string(),
+            "tree/branch1/".to_string(),
+            "tree/branch1/leaf".to_string(),
+            "tree/branch2/".to_string(),
+            "tree/branch2/leaf".to_string(),
+        ],
+        "file list inside the archive did not match"
+    );
+}
+
+#[tokio::test]
+#[cfg(feature = "tokio_support")]
+async fn successfully_list_archive_files_tokio() {
+    let source = tokio::fs::File::open("tests/fixtures/tree.tar")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        tokio_support::list_archive_files(source).await.unwrap(),
         vec![
             "tree/".to_string(),
             "tree/branch1/".to_string(),
@@ -192,6 +310,60 @@ fn uncompress_same_file_not_preserve_owner() {
     .expect("Failed to uncompress the file");
 }
 
+#[async_std::test]
+#[cfg(feature = "futures_support")]
+async fn uncompress_same_file_not_preserve_owner_futures() {
+    futures_support::uncompress_archive(
+        &mut async_std::fs::File::open("tests/fixtures/tree.tar")
+            .await
+            .unwrap(),
+        tempfile::TempDir::new()
+            .expect("Failed to create the tmp directory")
+            .path(),
+        Ownership::Ignore,
+    )
+    .await
+    .expect("Failed to uncompress the file");
+    futures_support::uncompress_archive(
+        &mut async_std::fs::File::open("tests/fixtures/tree.tar")
+            .await
+            .unwrap(),
+        tempfile::TempDir::new()
+            .expect("Failed to create the tmp directory")
+            .path(),
+        Ownership::Ignore,
+    )
+    .await
+    .expect("Failed to uncompress the file");
+}
+
+#[tokio::test]
+#[cfg(feature = "tokio_support")]
+async fn uncompress_same_file_not_preserve_owner_tokio() {
+    tokio_support::uncompress_archive(
+        &mut tokio::fs::File::open("tests/fixtures/tree.tar")
+            .await
+            .unwrap(),
+        tempfile::TempDir::new()
+            .expect("Failed to create the tmp directory")
+            .path(),
+        Ownership::Ignore,
+    )
+    .await
+    .expect("Failed to uncompress the file");
+    tokio_support::uncompress_archive(
+        &mut tokio::fs::File::open("tests/fixtures/tree.tar")
+            .await
+            .unwrap(),
+        tempfile::TempDir::new()
+            .expect("Failed to create the tmp directory")
+            .path(),
+        Ownership::Ignore,
+    )
+    .await
+    .expect("Failed to uncompress the file");
+}
+
 #[test]
 fn uncompress_truncated_archive() {
     assert!(matches!(
@@ -199,6 +371,36 @@ fn uncompress_truncated_archive() {
             std::fs::File::open("tests/fixtures/truncated.log.gz").unwrap(),
             Vec::new()
         ),
+        Err(Error::Unknown)
+    ));
+}
+
+#[async_std::test]
+#[cfg(feature = "futures_support")]
+async fn uncompress_truncated_archive_futures() {
+    assert!(matches!(
+        futures_support::uncompress_data(
+            async_std::fs::File::open("tests/fixtures/truncated.log.gz")
+                .await
+                .unwrap(),
+            Vec::new()
+        )
+        .await,
+        Err(Error::Unknown)
+    ));
+}
+
+#[tokio::test]
+#[cfg(feature = "tokio_support")]
+async fn uncompress_truncated_archive_tokio() {
+    assert!(matches!(
+        tokio_support::uncompress_data(
+            tokio::fs::File::open("tests/fixtures/truncated.log.gz")
+                .await
+                .unwrap(),
+            Vec::new()
+        )
+        .await,
         Err(Error::Unknown)
     ));
 }


### PR DESCRIPTION
Similar to #24, but without duplicated functionality and more carefully thought out, although there might still be mistakes. This one does not change existing code at all, only adds new module named `tokio_support`. It works by calling functions from the root of the crate in thread where blocking is acceptable and communicates with this thread using channels, thus implementing `Read` and `Write` in terms of `AsyncRead` and `AsyncWrite`. This allows to use the library in applications that are based on Tokio, mainly in client/servers. A usage example named `async_uncompress_service` is provided, along with it sync version `uncompress_service` for comparison.