### PR TITLE
Allow Pkg-Config on Windows

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -2,7 +2,7 @@ fn main() {
     find_libarchive()
 }
 
-#[cfg(not(windows))]
+#[cfg(not(target_env = "msvc"))]
 fn find_libarchive() {
     pkg_config::Config::new()
         .atleast_version("3")
@@ -10,7 +10,7 @@ fn find_libarchive() {
         .expect("Unable to find libarchive");
 }
 
-#[cfg(windows)]
+#[cfg(target_env = "msvc")]
 fn find_libarchive() {
     vcpkg::Config::new()
         .find_package("libarchive")


### PR DESCRIPTION
Windows users can utilize Pkg-Config via MSYS2:

https://packages.msys2.org/package/mingw-w64-x86_64-pkg-config

This will likely be the case for "windows-gnu" Rust users. "windows-msvc" can
continue to use VcPkg as before. Linux and others can continue to use Pkg-Config
as well.

Fix #38