### PR TITLE
Install VcPkg/Pkg-Config depending on target env

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,10 @@
 ## [Unreleased] - ReleaseDate
 
 * Bump MSRV to 1.46. [#54]
+* Install VcPkg/Pkg-Config depending on target env. [#56]
 
 [#54]: https://github.com/OSSystems/compress-tools-rs/issues/54
+[#56]: https://github.com/OSSystems/compress-tools-rs/pull/56
 
 ## [0.11.1] - 2021-03-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,10 @@ argh = "0.1"
 async-std = { version = "1.6.3", features = ["attributes"] }
 tokio = { version = "1.0.0", features = ["fs", "net"] }
 
-[target.'cfg(target_os = "windows")'.build-dependencies]
+[target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2"
 
-[target.'cfg(not(target_os = "windows"))'.build-dependencies]
+[target.'cfg(not(target_env = "msvc"))'.build-dependencies]
 pkg-config = "0.3"
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ functionalities.
 ## Dependencies
 
 You must have `libarchive`, 3.2.0 or newer, properly installed on your
-system in order to use this. If building on *nix systems, `pkg-config` is
-used to locate the `libarchive`; on Windows `vcpkg` will be used to locating
-the `libarchive`.
+system in order to use this. If building on *nix and Windows GNU
+systems, `pkg-config` is used to locate the `libarchive`; on Windows
+MSVC, `vcpkg` will be used to locating the `libarchive`.
 
 The minimum supported Rust version is 1.46.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,9 @@
 //! # Dependencies
 //!
 //! You must have `libarchive`, 3.2.0 or newer, properly installed on your
-//! system in order to use this. If building on *nix systems, `pkg-config` is
-//! used to locate the `libarchive`; on Windows `vcpkg` will be used to locating
-//! the `libarchive`.
+//! system in order to use this. If building on *nix and Windows GNU
+//! systems, `pkg-config` is used to locate the `libarchive`; on Windows
+//! MSVC, `vcpkg` will be used to locating the `libarchive`.
 //!
 //! The minimum supported Rust version is 1.46.
 //!


### PR DESCRIPTION
Although #39 was merged, `Cargo.toml` still required VcPkg on Windows, regardless of used toolchain. This meant that when someone tried to build `compress-tools` on `windows-gnu`, build script failed because it wasn't able to find `pkg-config` module.

This PR updates `Cargo.toml` to require either VcPkg or Pkg-Config depending on target env, just like `build.rs` since #39. It also updates docs and readme to indicate this.