### PR TITLE
Fix invalid display attribute causing build error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,11 @@
 
 * Bump MSRV to 1.46. [#54]
 * Install VcPkg/Pkg-Config depending on target env. [#56]
+* Fix invalid display attribute causing build error [#58]
 
 [#54]: https://github.com/OSSystems/compress-tools-rs/issues/54
 [#56]: https://github.com/OSSystems/compress-tools-rs/pull/56
+[#58]: https://github.com/OSSystems/compress-tools-rs/pull/58
 
 ## [0.11.1] - 2021-03-07
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,14 +14,14 @@ pub enum Error {
     #[display(fmt = "Extraction error: '{}'", _0)]
     Extraction(#[error(not(source))] String),
 
-    #[display(transparent)]
+    #[display(fmt = "{}", _0)]
     Io(io::Error),
 
-    #[display(transparent)]
+    #[display(fmt = "{}", _0)]
     Utf(std::str::Utf8Error),
 
     #[cfg(feature = "tokio_support")]
-    #[display(transparent)]
+    #[display(fmt = "{}", _0)]
     JoinError(tokio::task::JoinError),
 
     #[display(fmt = "Error to create the archive struct, is null")]


### PR DESCRIPTION
From derive_more 0.99.4, the invalid display attribute meta will be
marked as an error and returned.

ref: https://github.com/JelteF/derive_more/commit/a5d00057