### PR TITLE
Use "lossy" strings for invalid filenames

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+* Use "lossy" strings for invalid filenames. [#59]
+
+[#59]: https://github.com/OSSystems/compress-tools-rs/issues/59
+
 ## [0.11.2] - 2021-05-29
 
 * Bump MSRV to 1.46. [#54]

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,8 +16,6 @@ pub enum Error {
 
     Io(io::Error),
 
-    Utf(std::str::Utf8Error),
-
     #[cfg(feature = "tokio_support")]
     JoinError(tokio::task::JoinError),
 


### PR DESCRIPTION
There is no good way to handle the invalid filenames as we don't offer a
way to process those filenames before uncompressing the files. Now, if
there are invalid filenames we use "lossy" strings and don't fail to
process it.

Fixes: #59.
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>