### PR TITLE
Add an "uncompress_archive_callback" method.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ## [Unreleased] - ReleaseDate
 
 * Use "lossy" strings for invalid filenames. [#59]
+* Add `uncompress_archive_callback`
 
 [#59]: https://github.com/OSSystems/compress-tools-rs/issues/59
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,7 @@ pub struct Continue(pub bool);
 /// use std::path::Path;
 ///
 /// let mut source = File::open("tree.tar.gz")?;
-/// let callback = |name, bytes| {
+/// let callback = |name, bytes: Vec<u8>| {
 ///     println!("Read file {}: {} bytes", name, bytes.len());
 ///     Continue(true)
 /// };


### PR DESCRIPTION
This allows efficient reading of every file in the archive into memory
and can be used to extract an entire archive without needing to write
files to disk under their original names.