### PR TITLE
cicd: windows: Use vcpkg 2021.05.12 release

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,11 +26,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install libarchive
-        uses: lukka/run-vcpkg@v7
+        uses: lukka/run-vcpkg@v7.4
         with:
-          vcpkgArguments: "libarchive"
+          vcpkgArguments: libarchive
           vcpkgTriplet: x64-windows
-          vcpkgGitCommitId: ec6fe06e8da05a8157dc8581fa96b36b571c1bd5 # 2020.11-1
+          vcpkgGitCommitId: 7dbc05515b44bf54d2a42b4da9d1e1f910868b86 # master
+          useShell: true
 
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>