### PR TITLE
Improve Windows GitHub Action

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,27 +17,22 @@ jobs:
           - 1.46.0 # MSRV
           - stable
           - nightly
+        linkage:
+          - x64-windows
+          - x64-windows-static
 
-    name: Test ${{ matrix.version }} - x86_64-pc-windows-msvc
+    name: Test ${{ matrix.version }} ${{ matrix.linkage }} - x86_64-pc-windows-msvc
     runs-on: windows-latest
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install libarchive dynamic
+      - name: Install libarchive
         uses: lukka/run-vcpkg@v7.4
         with:
           vcpkgArguments: libarchive
-          vcpkgTriplet: x64-windows
-          vcpkgGitCommitId: 7dbc05515b44bf54d2a42b4da9d1e1f910868b86 # master
-          useShell: true
-
-      - name: Install libarchive static
-        uses: lukka/run-vcpkg@v7.4
-        with:
-          vcpkgArguments: libarchive
-          vcpkgTriplet: x64-windows-static
+          vcpkgTriplet: ${{ matrix.linkage }}
           vcpkgGitCommitId: 7dbc05515b44bf54d2a42b4da9d1e1f910868b86 # master
           useShell: true
 
@@ -68,40 +63,23 @@ jobs:
           path: target
           key: ${{ matrix.version }}-x86_64-pc-windows-msvc-cargo-build-trimmed-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Check dynamic build
+      - name: Check build
         uses: actions-rs/cargo@v1
         env:
-          OPENSSL_ROOT_DIR: "D:\\a\\compress-tools\\vcpkg\\installed\\x64-windows"
-          VCPKGRS_DYNAMIC: 1
+          RUSTFLAGS: ${{ matrix.linkage == 'x64-windows-static' && '-C target-feature=+crt-static' || '' }}
+          OPENSSL_ROOT_DIR: 'D:\\a\\compress-tools\\vcpkg\\installed\\${{ matrix.linkage }}'
+          VCPKGRS_DYNAMIC: ${{ matrix.linkage == 'x64-windows' && 1 || 0 }}
         with:
           command: check
           args: --release --all --bins --examples --tests
 
-      - name: Check static build
-        uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: "-C target-feature=+crt-static"
-          OPENSSL_ROOT_DIR: "D:\\a\\compress-tools\\vcpkg\\installed\\x64-windows-static"
-        with:
-          command: check
-          args: --release --all --bins --examples --tests
-
-      - name: Test dynamic
+      - name: Test
         uses: actions-rs/cargo@v1
         timeout-minutes: 10
         env:
-          OPENSSL_ROOT_DIR: "D:\\a\\compress-tools\\vcpkg\\installed\\x64-windows"
-          VCPKGRS_DYNAMIC: 1
-        with:
-          command: test
-          args: --release --all --all-features --no-fail-fast -- --nocapture
-
-      - name: Test static
-        uses: actions-rs/cargo@v1
-        timeout-minutes: 10
-        env:
-          RUSTFLAGS: "-C target-feature=+crt-static"
-          OPENSSL_ROOT_DIR: "D:\\a\\compress-tools\\vcpkg\\installed\\x64-windows-static"
+          RUSTFLAGS: ${{ matrix.linkage == 'x64-windows-static' && '-C target-feature=+crt-static' || '' }}
+          OPENSSL_ROOT_DIR: 'D:\\a\\compress-tools\\vcpkg\\installed\\${{ matrix.linkage }}'
+          VCPKGRS_DYNAMIC: ${{ matrix.linkage == 'x64-windows' && 1 || 0 }}
         with:
           command: test
           args: --release --all --all-features --no-fail-fast -- --nocapture


### PR DESCRIPTION
Add an additional matrix parameter named 'linkage'. This parameter has values corresponding to the vcpkg triplet used to install
libarchive, but effectively represents whether a static or dynamic build is being run/created.

Depending on which value of the 'linkage' parameter the job is run with, different environment variables are emitted to cargo, thus changing how the library is built as well as the version of libarchive installed by vcpkg.

This does mean that the Windows action now creates 6 jobs instead of 3.