### PR TITLE
enable static linking

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -13,8 +13,19 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Install Dependencies
-        run: sudo apt-get update; sudo apt-get install libarchive-dev
-      - uses: actions/checkout@v3
+        run: |
+          sudo apt-get update
+          sudo apt install libarchive-dev \
+            libicu-dev \
+            nettle-dev \
+            libacl1-dev \
+            liblzma-dev \
+            libzstd-dev \
+            liblz4-dev \
+            libbz2-dev \
+            zlib1g-dev \
+            libxml2-dev
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,18 @@ jobs:
 
     steps:
       - name: Install Dependencies
-        run: sudo apt-get update; sudo apt-get install libarchive-dev
+        run: |
+          sudo apt-get update
+          sudo apt install libarchive-dev \
+            libicu-dev \
+            nettle-dev \
+            libacl1-dev \
+            liblzma-dev \
+            libzstd-dev \
+            liblz4-dev \
+            libbz2-dev \
+            zlib1g-dev \
+            libxml2-dev
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Install ${{ matrix.version }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Dependencies
         run: |
           brew install pkgconfig
-          brew install libarchive
+          brew install libarchive icu4c bzip2 lz4 zlib expat
           echo PKG_CONFIG_PATH=$(brew ls libarchive | grep .pc$ | sed 's|/libarchive.pc||') >> $GITHUB_ENV
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+* Enable static linking via feature flag
 
 ## [0.14.3] - 2023-05-26
 
@@ -70,6 +71,7 @@
 * Raise MSRV to 1.49.0
 * Upgrade tokio-util to 0.7.0
 * Fix absolute paths being extracted outside of destination directory [#83]
+* Enable static linking via feature flag
 
 [#81]: https://github.com/OSSystems/compress-tools-rs/issues/81
 [#83]: https://github.com/OSSystems/compress-tools-rs/issues/83

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ libc = "0.2.86"
 async_support = ["async-trait", "futures-channel", "futures-core", "futures-io", "futures-util", "futures-executor"]
 futures_support = ["async_support", "blocking"]
 tokio_support = ["async_support", "tokio", "tokio-util"]
+static = []
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/src/build.rs
+++ b/src/build.rs
@@ -8,10 +8,17 @@ fn main() {
 
 #[cfg(not(target_env = "msvc"))]
 fn find_libarchive() {
-    pkg_config::Config::new()
-        .atleast_version("3.2.0")
-        .probe("libarchive")
-        .expect("Unable to find libarchive");
+    let mode = if cfg!(feature = "static") {
+        "static"
+    } else {
+        "dylib"
+    };
+
+    if mode == "static" {
+        link_deps(mode);
+    }
+
+    link_libarchive(mode);
 }
 
 #[cfg(target_env = "msvc")]
@@ -23,4 +30,97 @@ fn find_libarchive() {
     println!("cargo:rustc-link-lib=static=archive");
     println!("cargo:rustc-link-lib=User32");
     println!("cargo:rustc-link-lib=Crypt32");
+}
+
+#[cfg(not(target_env = "msvc"))]
+fn link_libarchive(mode: &str) {
+    let libarchive = pkg_config::Config::new()
+        .atleast_version("3.2.0")
+        .statik(mode == "static")
+        .probe("libarchive")
+        .expect("Unable to find libarchive");
+
+    for link_path in libarchive.link_paths {
+        println!("cargo:rustc-link-search=native={}", link_path.display());
+    }
+
+    for lib in libarchive.libs {
+        println!("cargo:rustc-link-lib={}={}", mode, lib);
+    }
+}
+
+#[cfg(not(target_env = "msvc"))]
+fn link_deps(mode: &str) {
+    find_link_paths();
+
+    #[cfg(target_os = "linux")]
+    println!("cargo:rustc-link-lib=dylib=stdc++");
+
+    #[cfg(target_os = "macos")]
+    {
+        println!("cargo:rustc-link-search=native=/usr/local/opt/bzip2/lib");
+        link_expat(mode);
+        link_iconv(mode);
+    }
+
+    link_icuuc(mode);
+}
+
+#[cfg(not(target_env = "msvc"))]
+fn find_link_paths() {
+    let pc_path = pkg_config::get_variable("pkg-config", "pc_path").expect("failed to get pc_path");
+
+    for path in pc_path.split(":") {
+        println!(
+            "cargo:rustc-link-search=native={}",
+            path.replace("/pkgconfig", "")
+        );
+    }
+
+    if let Ok(pkg_config_path) = std::env::var("PKG_CONFIG_PATH") {
+        for path in pkg_config_path.split(":") {
+            println!(
+                "cargo:rustc-link-search=native={}",
+                path.replace("/pkgconfig", "")
+            );
+        }
+    }
+}
+
+#[cfg(not(target_env = "msvc"))]
+fn link(name: &str, mode: &str) -> pkg_config::Library {
+    let lib = pkg_config::Config::new()
+        .statik(mode == "static")
+        .probe(name)
+        .expect(format!("unable to find {}", name).as_str());
+
+    for link_path in lib.link_paths.iter() {
+        println!("cargo:rustc-link-search=native={}", link_path.display());
+    }
+
+    lib
+}
+
+#[cfg(target_os = "macos")]
+fn link_expat(mode: &str) {
+    let expat = link("expat", mode);
+
+    for lib in expat.libs {
+        println!("cargo:rustc-link-lib={}={}", mode, lib);
+    }
+}
+
+#[cfg(not(target_env = "msvc"))]
+fn link_icuuc(mode: &str) {
+    let _ = link("icu-uc", mode);
+
+    println!("cargo:rustc-link-lib={}=icuuc", mode);
+    println!("cargo:rustc-link-lib={}=icudata", mode);
+}
+
+#[cfg(target_os = "macos")]
+fn link_iconv(mode: &str) {
+    if mode == "static" {
+        println!("cargo:rustc-link-search=/usr/local/opt/libiconv/lib/")
+    }
 }


### PR DESCRIPTION
pkg-config can't statically link libraries inside `/usr/lib` which usually where libraries are installed as stated here https://github.com/rust-lang/pkg-config-rs/issues/102

This PR enable static linking via feature flags. To test extra dependencies is needed

Linux

```
sudo apt install libarchive-dev \
    libicu-dev \
    nettle-dev \
    libacl1-dev \
    liblzma-dev \
    libzstd-dev \
    liblz4-dev \
    libbz2-dev \
    zlib1g-dev \
    libxml2-dev
```

macOS

```
brew install icu4c libarchive bzip2 lz4 zlib expat
EXPORT PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig:/usr/local/opt/libarchive/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig:/usr/local/opt/expat/lib/pkgconfig"
```