### PR TITLE
Drop unnecessary lifetime annotations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 * Raise MSRV to 1.59.0
 * Change to 2021 edition
+* Drop lifetime annotations of reader parameter in `ArchiveIterator::from_read`
+  and `ArchiveIterator::from_read_with_encoding` [#90]
 
 ## [0.13.0] - 2022-08-03
 

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -126,7 +126,7 @@ impl<R: Read + Seek> ArchiveIterator<R> {
     /// ```
     pub fn from_read_with_encoding(source: R, decode: DecodeCallback) -> Result<ArchiveIterator<R>>
     where
-        R: Read + Seek + 'static,
+        R: Read + Seek,
     {
         let utf8_guard = ffi::UTF8LocaleGuard::new();
         let reader = source;
@@ -231,7 +231,7 @@ impl<R: Read + Seek> ArchiveIterator<R> {
     /// ```
     pub fn from_read(source: R) -> Result<ArchiveIterator<R>>
     where
-        R: Read + Seek + 'static,
+        R: Read + Seek,
     {
         ArchiveIterator::from_read_with_encoding(source, crate::decode_utf8)
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use compress_tools::*;
-use std::path::Path;
+use std::{
+    io::{Cursor, Read},
+    path::Path,
+};
 
 #[test]
 fn get_compressed_file_content() {
@@ -629,6 +632,28 @@ fn iterate_truncated_archive() {
     }
 
     panic!("Did not find expected error");
+}
+
+fn uncompress_bytes_helper(bytes: &[u8]) {
+    let wrapper = Cursor::new(bytes);
+
+    for content in ArchiveIterator::from_read(wrapper).unwrap() {
+        if let ArchiveContents::Err(Error::Unknown) = content {
+            return;
+        }
+    }
+
+    panic!("Did not find expected error");
+}
+
+#[test]
+fn uncompress_bytes() {
+    let mut source = std::fs::File::open("tests/fixtures/truncated.log.gz").unwrap();
+
+    let mut buffer = Vec::new();
+    source.read_to_end(&mut buffer).unwrap();
+
+    uncompress_bytes_helper(&buffer)
 }
 
 #[test]


### PR DESCRIPTION
The `'static` lifetime annotations on `ArchiveIterator::read_from()` hinder the usage on non-local variables, e.g. a given slice of bytes wrapped in std::core::Cursor.