### PR TITLE
RFC: Increase buffer size

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     interval: daily
     time: "08:00"
   open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -44,17 +44,17 @@ jobs:
         with:
           command: generate-lockfile
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-registry-trimmed-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo index
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-index-trimmed-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo build
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: target
           key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-build-trimmed-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,17 +41,17 @@ jobs:
         with:
           command: generate-lockfile
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ matrix.version }}-x86_64-apple-darwin-cargo-registry-trimmed-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo index
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ matrix.version }}-x86_64-apple-darwin-cargo-index-trimmed-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo build
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: target
           key: ${{ matrix.version }}-x86_64-apple-darwin-cargo-build-trimmed-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache vcpkg installed
-        uses: actions/cache@v1.0.3
+        uses: actions/cache@v3
         with:
           path: $VCPKG_ROOT/installed
           key: ${{ runner.os }}-vcpkg-cache-${{ matrix.linkage }}
@@ -37,7 +37,7 @@ jobs:
           VCPKG_ROOT: 'C:\vcpkg'
 
       - name: Cache vcpkg downloads
-        uses: actions/cache@v1.0.3
+        uses: actions/cache@v3
         with:
           path: $VCPKG_ROOT/downloads
           key: ${{ runner.os }}-vcpkg-cache-${{ matrix.linkage }}
@@ -61,17 +61,17 @@ jobs:
         with:
           command: generate-lockfile
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ matrix.version }}-x86_64-pc-windows-msvc-cargo-registry-trimmed-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo index
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ matrix.version }}-x86_64-pc-windows-msvc-cargo-index-trimmed-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo build
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: target
           key: ${{ matrix.version }}-x86_64-pc-windows-msvc-cargo-build-trimmed-${{ hashFiles('**/Cargo.lock') }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
   and `ArchiveIterator::from_read_with_encoding` [#90]
 * Forward name decode failures in `ArchiveIterator::from_read` and
   `ArchiveIterator::from_read_with_encoding` instead of panicking [#91]
+* Increase internal used buffersize [#93]
 
 ## [0.13.0] - 2022-08-03
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ use std::{
     slice,
 };
 
-const READER_BUFFER_SIZE: usize = 1024;
+const READER_BUFFER_SIZE: usize = 16384;
 
 /// Determine the ownership behavior when unpacking the archive.
 pub enum Ownership {


### PR DESCRIPTION
Tested against cov-analysis-linux64-2022.06.tar.gz (1.2G) with /tmp mounted on a tmpfs:

    $ hyperfine -w 1 -m 10 -c 'rm -Rf /tmp/benchtest/*' './target/release/examples/uncompress_tool uncompress-archive cov-analysis-linux64-2022.06.tar.gz /tmp/benchtest true'
    Benchmark 1: ./target/release/examples/uncompress_tool uncompress-archive cov-analysis-linux64-2022.06.tar.gz /tmp/benchtest true
      Time (mean ± σ):      9.516 s ±  0.053 s    [User: 7.088 s, System: 2.401 s]
      Range (min … max):    9.462 s …  9.626 s    10 runs

    $ hyperfine -w 1 -m 10 -c 'rm -Rf /tmp/benchtest/*' './target/release/examples/uncompress_tool uncompress-archive cov-analysis-linux64-2022.06.tar.gz /tmp/benchtest true'
    Benchmark 1: ./target/release/examples/uncompress_tool uncompress-archive cov-analysis-linux64-2022.06.tar.gz /tmp/benchtest true
      Time (mean ± σ):      8.055 s ±  0.027 s    [User: 6.386 s, System: 1.643 s]
      Range (min … max):    8.008 s …  8.085 s    10 runs