### PR TITLE
Please several clippy pedantic issues

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 fn main() {
-    find_libarchive()
+    find_libarchive();
 }
 
 #[cfg(not(target_env = "msvc"))]

--- a/src/ffi/locale.rs
+++ b/src/ffi/locale.rs
@@ -39,10 +39,10 @@ mod inner {
                 )
             };
 
-            let save = if !utf8_locale.is_null() {
-                unsafe { libc::uselocale(utf8_locale) }
-            } else {
+            let save = if utf8_locale.is_null() {
                 std::ptr::null_mut()
+            } else {
+                unsafe { libc::uselocale(utf8_locale) }
             };
 
             Self { save, utf8_locale }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,7 +1,6 @@
 use std::{
     ffi::{CStr, CString},
     io::{Read, Seek, SeekFrom, Write},
-    ops::DerefMut,
     slice,
 };
 
@@ -38,6 +37,7 @@ pub enum ArchiveContents {
 }
 
 /// An iterator over the contents of an archive.
+#[allow(clippy::module_name_repetitions)]
 pub struct ArchiveIterator<R: Read + Seek> {
     archive_entry: *mut ffi::archive_entry,
     archive_reader: *mut ffi::archive,
@@ -168,7 +168,7 @@ impl<R: Read + Seek> ArchiveIterator<R> {
                 archive_result(
                     ffi::archive_read_open(
                         archive_reader,
-                        (pipe.deref_mut() as *mut HeapReadSeekerPipe<R>) as *mut c_void,
+                        std::ptr::addr_of_mut!(*pipe) as *mut c_void,
                         None,
                         Some(libarchive_heap_seekableread_callback::<R>),
                         None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ use std::{
 const READER_BUFFER_SIZE: usize = 16384;
 
 /// Determine the ownership behavior when unpacking the archive.
+#[derive(Clone, Copy, Debug)]
 pub enum Ownership {
     /// Preserve the ownership of the files when uncompressing the archive.
     Preserve,
@@ -456,7 +457,7 @@ where
             archive_result(
                 ffi::archive_read_open(
                     archive_reader,
-                    (&mut pipe as *mut SeekableReaderPipe) as *mut c_void,
+                    std::ptr::addr_of_mut!(pipe) as *mut c_void,
                     None,
                     Some(libarchive_seekable_read_callback),
                     None,
@@ -513,7 +514,7 @@ where
             archive_result(
                 ffi::archive_read_open(
                     archive_reader,
-                    (&mut pipe as *mut ReaderPipe) as *mut c_void,
+                    std::ptr::addr_of_mut!(pipe) as *mut c_void,
                     None,
                     Some(libarchive_read_callback),
                     None,


### PR DESCRIPTION
    warning: consider adding a `;` to the last statement for consistent formatting
     --> src/build.rs:6:5
      |
    6 |     find_libarchive()
      |     ^^^^^^^^^^^^^^^^^ help: add a `;` here: `find_libarchive();`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#semicolon_if_nothing_returned

    warning: this argument is passed by value, but not consumed in the function body
       --> src/lib.rs:397:41
        |
    397 | fn run_with_archive<F, R, T>(ownership: Ownership, mut reader: R, f: F) -> Result<T>
        |                                         ^^^^^^^^^ help: consider taking a reference instead: `&Ownership`
        |
    help: consider marking this type as `Copy`
       --> src/lib.rs:75:1
        |
    75  | pub enum Ownership {
        | ^^^^^^^^^^^^^^^^^^
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_value

    warning: item name ends with its containing module's name
      --> src/iterator.rs:47:1
       |
    47 | / pub struct ArchiveIterator<R: Read + Seek> {
    48 | |     archive_entry: *mut ffi::archive_entry,
    49 | |     archive_reader: *mut ffi::archive,
    50 | |
    ...  |
    58 | |     _utf8_guard: UTF8LocaleGuard,
    59 | | }
       | |_^
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#module_name_repetitions

    warning: unnecessary boolean `not` operation
      --> src/ffi/locale.rs:42:24
       |
    42 |               let save = if !utf8_locale.is_null() {
       |  ________________________^
    43 | |                 unsafe { libc::uselocale(utf8_locale) }
    44 | |             } else {
    45 | |                 std::ptr::null_mut()
    46 | |             };
       | |_____________^
       |
       = help: remove the `!` and swap the blocks of the `if`/`else`
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#if_not_else

    warning: borrow as raw pointer
       --> src/lib.rs:459:21
        |
    459 |                     (&mut pipe as *mut SeekableReaderPipe) as *mut c_void,
        |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::addr_of_mut!(pipe)`
        |
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#borrow_as_ptr

    warning: borrow as raw pointer
       --> src/lib.rs:516:21
        |
    516 |                     (&mut pipe as *mut ReaderPipe) as *mut c_void,
        |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::addr_of_mut!(pipe)`

    warning: explicit `deref_mut` method call
       --> src/iterator.rs:171:26
        |
    171 |                         (pipe.deref_mut() as *mut HeapReadSeekerPipe<R>) as *mut c_void,
        |                          ^^^^^^^^^^^^^^^^ help: try this: `&mut *pipe`
        |
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_deref_methods