### PR TITLE
fix: fatal runtime error: stack overflow when try use ArchiveIteratorBuilder.filter()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+* Fix call stack runtime error on filter from `ArchiveIterator` [#113]
+
+[#113]: https://github.com/OSSystems/compress-tools-rs/pull/113
+
 ## [0.14.1] - 2023-03-21
 
 * Add illumos compilation support [#99]


### PR DESCRIPTION
### problem 
When trying to use the "filter" function of ArchiveIteratorBuilder in "rar/zip/7z" with large amounts of files `( in my case 24 thousand )` and implement some rule in the "filter", the program ends up breaking if it doesn't "match" during thousands of files traversed, because if the "filter" does not "match" during each chunk, it calls "self.next()" again recursively to process the next chunk/header, thus filling the call stack and causing a "fatal runtime error".

### solution
I removed the recursion and added a loop.