### PR TITLE
Avoid NPE when `ffi::archive_read_data_block` returns a null block

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -618,6 +618,10 @@ where
             value => archive_result(value, archive_reader)?,
         }
 
+        if size == 0 {
+            continue;
+        }
+
         let content = slice::from_raw_parts(buffer as *const u8, size);
         target.write_all(content)?;
         written += size;


### PR DESCRIPTION
I have no idea why libarchive does this but it's a thing