### PR TITLE
fix: use slice::from_raw_parts only if size > 0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
 ## [Unreleased] - ReleaseDate
 
 * Raise MSRV to 1.63.0
+* Fix use slice::from_raw_parts only if size > 0 [#126]
+
+[#126]: https://github.com/OSSystems/compress-tools-rs/pull/126
 
 ## [0.14.3] - 2023-05-26
 


### PR DESCRIPTION
libarchive seems to pass a nullptr with size 0 to the archive_read_data_block callback. This leads to a precondition violated assert in debug builds.