### PR TITLE
feat(build): add selective static compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,11 @@ all-features = true
 coveralls = { repository = "ossystems/compress-tools-rs" }
 
 [dependencies]
-derive_more = { version = "0.99", default-features = false, features = ["display", "from", "error"] }
+derive_more = { version = "0.99", default-features = false, features = [
+    "display",
+    "from",
+    "error",
+] }
 async-trait = { version = "0.1.39", optional = true }
 futures-channel = { version = "0.3.5", features = ["sink"], optional = true }
 futures-core = { version = "0.3.5", optional = true }
@@ -32,15 +36,42 @@ futures-io = { version = "0.3.5", optional = true }
 futures-util = { version = "0.3.5", features = ["sink", "io"], optional = true }
 futures-executor = { version = "0.3.5", optional = true }
 blocking = { version = "1.0.0", optional = true }
-tokio = { version = "1.0.0", features = ["rt-multi-thread", "macros", "fs", "net"], optional = true }
+tokio = { version = "1.0.0", features = [
+    "rt-multi-thread",
+    "macros",
+    "fs",
+    "net",
+], optional = true }
 tokio-util = { version = "0.7.0", features = ["compat"], optional = true }
 libc = "0.2.86"
 
 [features]
-async_support = ["async-trait", "futures-channel", "futures-core", "futures-io", "futures-util", "futures-executor"]
+async_support = [
+    "async-trait",
+    "futures-channel",
+    "futures-core",
+    "futures-io",
+    "futures-util",
+    "futures-executor",
+]
 futures_support = ["async_support", "blocking"]
 tokio_support = ["async_support", "tokio", "tokio-util"]
-static = []
+static = [
+    "static_b2",
+    "static_lz4",
+    "static_zstd",
+    "static_lzma",
+    "static_bz2",
+    "static_z",
+    "static_xml2",
+]
+static_b2 = []
+static_lz4 = []
+static_zstd = []
+static_lzma = []
+static_bz2 = []
+static_z = []
+static_xml2 = []
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/src/build.rs
+++ b/src/build.rs
@@ -50,6 +50,27 @@ fn find_libarchive() {
     if cfg!(feature = "static") {
         println!("cargo:rustc-link-lib=static=archive");
     }
+    if cfg!(feature = "static_b2") {
+        println!("cargo:rustc-link-lib=static=b2");
+    }
+    if cfg!(feature = "static_lz4") {
+        println!("cargo:rustc-link-lib=static=lz4");
+    }
+    if cfg!(feature = "static_zstd") {
+        println!("cargo:rustc-link-lib=static=zstd");
+    }
+    if cfg!(feature = "static_lzma") {
+        println!("cargo:rustc-link-lib=static=lzma");
+    }
+    if cfg!(feature = "static_bz2") {
+        println!("cargo:rustc-link-lib=static=bz2");
+    }
+    if cfg!(feature = "static_z") {
+        println!("cargo:rustc-link-lib=static=z");
+    }
+    if cfg!(feature = "static_xml2") {
+        println!("cargo:rustc-link-lib=static=xml2");
+    }
 }
 
 #[cfg(target_env = "msvc")]


### PR DESCRIPTION
I noticed that the `static` feature flag existed, but it only made the `libarchive` part statically compiled, so I added a bunch of features that should make it easier for people to statically link compression libraries, or use the `static` feature to link pretty much everything.