### PR TITLE
add missing link library advapi32 to build

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -61,4 +61,5 @@ fn find_libarchive() {
     println!("cargo:rustc-link-lib=static=archive");
     println!("cargo:rustc-link-lib=User32");
     println!("cargo:rustc-link-lib=Crypt32");
+    println!("cargo:rustc-link-lib=advapi32");
 }


### PR DESCRIPTION
The build failed for me citing missing symbols for advapi32 (i'm on windows with VS 2022).