### PR TITLE
Propagate ENOSPC during archive extraction (fixes #142)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,11 +6,13 @@
 
 * Fix partial unfinished archive reads [#133]
 * Add missing `advapi32` link library on Windows builds [#141]
+* Propagate `ENOSPC` during archive extraction instead of silently truncating files [#144]
 * flake: add `libb2`, `lz4`, and `zstd` to the development shell [#145]
 * Raise MSRV to 1.82.0 to match dependency tree [#146]
 
 [#133]: https://github.com/OSSystems/compress-tools-rs/pull/133
 [#141]: https://github.com/OSSystems/compress-tools-rs/pull/141
+[#144]: https://github.com/OSSystems/compress-tools-rs/pull/144
 [#145]: https://github.com/OSSystems/compress-tools-rs/pull/145
 [#146]: https://github.com/OSSystems/compress-tools-rs/pull/146
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,19 @@ pub(crate) fn archive_result(value: i32, archive: *mut ffi::archive) -> Result<(
     }
 }
 
+/// Like [`archive_result`], but treats `ARCHIVE_WARN` as an error.
+///
+/// Use this on call sites where a warning indicates user-visible data loss —
+/// for example, `archive_write_header` and `archive_write_data_block`, which
+/// can return `ARCHIVE_WARN` when the target filesystem returns `ENOSPC`. See
+/// https://github.com/OSSystems/compress-tools-rs/issues/142.
+pub(crate) fn archive_result_strict(value: i32, archive: *mut ffi::archive) -> Result<()> {
+    match value {
+        ffi::ARCHIVE_OK => Ok(()),
+        _ => Err(Error::from(archive)),
+    }
+}
+
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 impl From<*mut ffi::archive> for Error {
     fn from(input: *mut ffi::archive) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ mod iterator;
 #[cfg(feature = "tokio_support")]
 pub mod tokio_support;
 
-use error::archive_result;
+use error::{archive_result, archive_result_strict};
 pub use error::{Error, Result};
 use io::{Seek, SeekFrom};
 pub use iterator::{ArchiveContents, ArchiveIterator, ArchiveIteratorBuilder};
@@ -273,10 +273,13 @@ where
                     ffi::archive_entry_set_hardlink(entry, target_path.as_ptr());
                 }
 
-                ffi::archive_write_header(archive_writer, entry);
+                archive_result_strict(
+                    ffi::archive_write_header(archive_writer, entry),
+                    archive_writer,
+                )?;
                 libarchive_copy_data(archive_reader, archive_writer)?;
 
-                archive_result(
+                archive_result_strict(
                     ffi::archive_write_finish_entry(archive_writer),
                     archive_writer,
                 )?;
@@ -573,7 +576,7 @@ fn libarchive_copy_data(
                 value => archive_result(value, archive_reader)?,
             }
 
-            archive_result(
+            archive_result_strict(
                 /* Might depending on the version of libarchive on success
                  * return 0 or the number of bytes written,
                  * see man:archive_write_data(3) */

--- a/tests/disk_full_test.rs
+++ b/tests/disk_full_test.rs
@@ -1,0 +1,177 @@
+// Copyright (C) 2026 O.S. Systems Software LTDA
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Regression test for https://github.com/OSSystems/compress-tools-rs/issues/142
+//!
+//! When `uncompress_archive` cannot write file contents (disk full) the error
+//! must propagate as a `Result::Err`, not a silent `Ok` over truncated files.
+//!
+//! The only reliable way to trigger `ENOSPC` without root is to mount a tiny
+//! `tmpfs` inside an unprivileged user + mount namespace. The test forks a
+//! child, unshares into its own namespaces, mounts a 4 KiB `tmpfs`, and runs
+//! the extraction against an archive whose contents cannot fit. If the host
+//! kernel disallows unprivileged user namespaces (e.g. some hardened distros
+//! or CI sandboxes), the test is skipped rather than failed.
+
+#![cfg(target_os = "linux")]
+
+use compress_tools::{uncompress_archive, Ownership};
+use std::{
+    ffi::CString,
+    fs::{self, File},
+    io::Write,
+    os::unix::ffi::OsStrExt,
+    path::{Path, PathBuf},
+    process,
+};
+
+const SKIPPED: i32 = 77;
+const BUG_REPRODUCED: i32 = 1;
+const OK: i32 = 0;
+
+#[test]
+fn uncompress_archive_errors_when_target_is_full() {
+    let scratch = tempfile::tempdir().expect("tempdir");
+    let archive = build_oversize_archive(scratch.path());
+    let target = scratch.path().join("target");
+    fs::create_dir(&target).unwrap();
+
+    unsafe {
+        match libc::fork() {
+            -1 => panic!("fork failed: {}", std::io::Error::last_os_error()),
+            0 => run_child(&archive, &target),
+            pid => {
+                let mut status: libc::c_int = 0;
+                let waited = libc::waitpid(pid, &mut status, 0);
+                assert_eq!(
+                    waited, pid,
+                    "waitpid failed: {}",
+                    std::io::Error::last_os_error()
+                );
+                assert!(
+                    libc::WIFEXITED(status),
+                    "child did not exit normally (raw status = {status})"
+                );
+                match libc::WEXITSTATUS(status) {
+                    OK => {}
+                    SKIPPED => {
+                        eprintln!(
+                            "skipping: unprivileged user namespaces or tmpfs \
+                             mount not available in this environment"
+                        );
+                    }
+                    BUG_REPRODUCED => panic!(
+                        "uncompress_archive returned Ok despite the target \
+                         partition being full — see issue #142"
+                    ),
+                    other => panic!("child exited with unexpected code {other}"),
+                }
+            }
+        }
+    }
+}
+
+unsafe fn run_child(archive: &Path, target: &Path) -> ! {
+    let uid = libc::getuid();
+    let gid = libc::getgid();
+
+    if libc::unshare(libc::CLONE_NEWUSER | libc::CLONE_NEWNS) != 0 {
+        eprintln!(
+            "child: unshare failed: {}",
+            std::io::Error::last_os_error()
+        );
+        process::exit(SKIPPED);
+    }
+
+    // Map our real uid/gid to 0 inside the new user namespace so that the
+    // subsequent mount() syscall has CAP_SYS_ADMIN over the new mount
+    // namespace.
+    if !write_proc("/proc/self/uid_map", &format!("0 {uid} 1"))
+        || !write_proc("/proc/self/setgroups", "deny")
+        || !write_proc("/proc/self/gid_map", &format!("0 {gid} 1"))
+    {
+        process::exit(SKIPPED);
+    }
+
+    // Make the entire namespace's mount propagation private so we don't leak
+    // mounts to the host (belt-and-braces; unshare(CLONE_NEWNS) already
+    // detaches).
+    let slash = CString::new("/").unwrap();
+    let empty = CString::new("").unwrap();
+    libc::mount(
+        empty.as_ptr(),
+        slash.as_ptr(),
+        std::ptr::null(),
+        libc::MS_REC | libc::MS_PRIVATE,
+        std::ptr::null(),
+    );
+
+    let source = CString::new("tmpfs").unwrap();
+    let fstype = CString::new("tmpfs").unwrap();
+    let options = CString::new("size=4K").unwrap();
+    let target_c = CString::new(target.as_os_str().as_bytes()).unwrap();
+    if libc::mount(
+        source.as_ptr(),
+        target_c.as_ptr(),
+        fstype.as_ptr(),
+        0,
+        options.as_ptr() as *const _,
+    ) != 0
+    {
+        eprintln!(
+            "child: mount tmpfs failed: {}",
+            std::io::Error::last_os_error()
+        );
+        process::exit(SKIPPED);
+    }
+
+    let mut src = match File::open(archive) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("child: open archive failed: {e}");
+            process::exit(SKIPPED);
+        }
+    };
+
+    let result = uncompress_archive(&mut src, target, Ownership::Ignore);
+    eprintln!("child: uncompress_archive result = {result:?}");
+    process::exit(if result.is_err() { OK } else { BUG_REPRODUCED });
+}
+
+unsafe fn write_proc(path: &str, content: &str) -> bool {
+    match File::options().write(true).open(path) {
+        Ok(mut f) => match f.write_all(content.as_bytes()) {
+            Ok(()) => true,
+            Err(e) => {
+                eprintln!("child: write to {path} failed: {e}");
+                false
+            }
+        },
+        Err(e) => {
+            eprintln!("child: open {path} failed: {e}");
+            false
+        }
+    }
+}
+
+/// Build a tar archive whose uncompressed contents are several times the size
+/// of the 4 KiB tmpfs we will mount in the child.
+fn build_oversize_archive(dir: &Path) -> PathBuf {
+    let src = dir.join("payload");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("a.bin"), vec![0xaa_u8; 8192]).unwrap();
+    fs::write(src.join("b.bin"), vec![0xbb_u8; 8192]).unwrap();
+
+    let archive = dir.join("oversize.tar");
+    let status = process::Command::new("tar")
+        .arg("-cf")
+        .arg(&archive)
+        .arg("-C")
+        .arg(&src)
+        .arg(".")
+        .status()
+        .expect("tar command must be available on Linux test hosts");
+    assert!(status.success(), "tar invocation failed");
+    archive
+}


### PR DESCRIPTION
## Summary

- Fixes silent truncation when `uncompress_archive` runs out of disk space (#142)
- Adds a `archive_result_strict` helper that treats `ARCHIVE_WARN` as an error, and routes the file-write path (`archive_write_header`, `archive_write_data_block`, `archive_write_finish_entry`) through it
- Keeps the tolerant `archive_result` on paths where warnings are benign (encoding of a tar filename, cleanup on close)
- Adds a Linux-only regression test that mounts a 4 KiB `tmpfs` inside an unprivileged user + mount namespace and asserts that the extraction fails instead of silently succeeding; the test self-skips when unprivileged user namespaces are not available

## Root cause

libarchive's disk writer reports `ENOSPC` from the underlying `write(2)` as `ARCHIVE_WARN`, not `ARCHIVE_FATAL`. The project's `archive_result` helper mapped `ARCHIVE_WARN` to `Ok(())`, so the write failure was swallowed. The call site for `archive_write_header` also dropped the return value entirely.

Reproducer from the issue:

```sh
unshare -r -m sh -exc '
  mkdir -p /tmp/ctfull
  mount -t tmpfs -o size=4K tmpfs /tmp/ctfull
  cargo run --example uncompress_tool -- uncompress-archive path/to/big.tar /tmp/ctfull false
  echo "exit=$?"
'
```

Before: `exit=0`, files on disk are zero-byte / truncated.
After:  `Error: Extraction("Write failed")`, exit non-zero.

## Test plan

- [x] `cargo test` — existing suite passes
- [x] `cargo test --features futures_support` — passes
- [x] `cargo test --features tokio_support` — passes
- [x] `cargo test --test disk_full_test` — fails pre-fix, passes post-fix (child logs `Err(Extraction("Write failed"))`)
- [x] Manual: `unshare -r -m` + `mount -t tmpfs -o size=4K` + extraction → now surfaces the error instead of silently creating empty files