### PR TITLE
flake: add libb2/lz4/zstd to dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,11 @@
             rust-bindgen
             pkg-config
             libarchive
+            # Required by the `static` feature (build.rs probes these via
+            # pkg-config when libarchive is linked statically).
+            libb2
+            lz4
+            zstd
             clang
             llvmPackages.libclang
 


### PR DESCRIPTION
## Summary

- \`src/build.rs\` probes \`libb2\`, \`liblz4\`, and \`libzstd\` via pkg-config when the \`static\` feature is enabled, so \`cargo build --features static\` (and by extension \`cargo build --all-features\`) fails inside the default nix dev shell with \"Unable to find libb2\" before any Rust code runs.
- This adds those three libraries to \`buildInputs\` so pkg-config can locate them.

## Caveat

A fully-static build still needs a **static** libarchive, which nixpkgs' default \`libarchive\` does not provide (only \`.so\`). This PR does not add a static libarchive — anyone wanting \`--features static\` in the dev shell still has to supply their own. The change just removes the pkg-config failures for the other three libs so the next error message is actionable instead of confusing.

## Test plan

- [x] \`nix develop --command cargo test\` — passes
- [x] \`nix develop --command cargo test --features "futures_support tokio_support"\` — passes (34 tests)