### PR TITLE
ci: bump MSRV to 1.71.0 to match dependency tree

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.71.0 # MSRV
+          toolchain: 1.82.0 # MSRV
           override: true
           components: clippy
 

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.65.0 # MSRV
+          toolchain: 1.71.0 # MSRV
           override: true
           components: clippy
 

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -27,6 +27,16 @@ jobs:
           command: fmt
           args: --all -- --check
 
+      - name: Install stable toolchain (MSRV-aware lockfile resolution)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+        env:
+          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.71.0 # MSRV

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.71.0 # MSRV
+          - 1.82.0 # MSRV
           - stable
           - nightly
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,6 +26,16 @@ jobs:
         run: sudo apt-get update; sudo apt-get install libarchive-dev libb2-dev liblz4-dev libacl1-dev libzstd-dev nettle-dev
       - name: Checkout sources
         uses: actions/checkout@v4
+      - name: Install stable toolchain (MSRV-aware lockfile resolution)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable-x86_64-unknown-linux-gnu
+          profile: minimal
+          override: true
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+        env:
+          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1
         with:
@@ -38,11 +48,6 @@ jobs:
         with:
           crate: grcov
           use-tool-cache: true
-
-      - name: Generate Cargo.lock
-        uses: actions-rs/cargo@v1
-        with:
-          command: generate-lockfile
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
           - nightly
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.71.0 # MSRV
+          - 1.82.0 # MSRV
           - stable
           - nightly
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,17 +29,22 @@ jobs:
           echo PKG_CONFIG_PATH=$(brew ls libarchive | grep .pc$ | sed 's|/libarchive.pc||') >> $GITHUB_ENV
       - name: Checkout sources
         uses: actions/checkout@v4
+      - name: Install stable toolchain (MSRV-aware lockfile resolution)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable-aarch64-apple-darwin
+          profile: minimal
+          override: true
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+        env:
+          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.version }}-aarch64-apple-darwin
           profile: minimal
           override: true
-
-      - name: Generate Cargo.lock
-        uses: actions-rs/cargo@v1
-        with:
-          command: generate-lockfile
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
           - nightly
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
           - nightly
         linkage:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.71.0 # MSRV
+          - 1.82.0 # MSRV
           - stable
           - nightly
         linkage:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,17 +49,22 @@ jobs:
         env:
           VCPKG_ROOT: 'C:\vcpkg'
 
+      - name: Install stable toolchain (MSRV-aware lockfile resolution)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable-x86_64-pc-windows-msvc
+          profile: minimal
+          override: true
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+        env:
+          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.version }}-x86_64-pc-windows-msvc
           profile: minimal
           override: true
-
-      - name: Generate Cargo.lock
-        uses: actions-rs/cargo@v1
-        with:
-          command: generate-lockfile
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
 build = "src/build.rs"
-rust-version = "1.71.0"
+rust-version = "1.82.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
 build = "src/build.rs"
-rust-version = "1.59.0"
+rust-version = "1.71.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ system in order to use this. If building on *nix and Windows GNU
 systems, `pkg-config` is used to locate the `libarchive`; on Windows
 MSVC, `vcpkg` will be used to locating the `libarchive`.
 
-The minimum supported Rust version is 1.59.
+The minimum supported Rust version is 1.71.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ system in order to use this. If building on *nix and Windows GNU
 systems, `pkg-config` is used to locate the `libarchive`; on Windows
 MSVC, `vcpkg` will be used to locating the `libarchive`.
 
-The minimum supported Rust version is 1.71.
+The minimum supported Rust version is 1.82.
 
 ## Features
 

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,8 @@
         rust-toolchain = with rust.packages.${system};
           let
             msrvToolchain = toolchainOf {
-              channel = "1.71.0";
-              sha256 = "sha256-ks0nMEGGXKrHnfv4Fku+vhQ7gx76ruv6Ij4fKZR3l78=";
+              channel = "1.82.0";
+              sha256 = "sha256-yMuSb5eQPO/bHv+Bcf/US8LVMbf/G/0MSfiPwBhiPpk=";
             };
           in
           combine [

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,8 @@
         rust-toolchain = with rust.packages.${system};
           let
             msrvToolchain = toolchainOf {
-              channel = "1.65.0";
-              sha256 = "sha256-DzNEaW724O8/B8844tt5AVHmSjSQ3cmzlU4BP90oRlY=";
+              channel = "1.71.0";
+              sha256 = "sha256-ks0nMEGGXKrHnfv4Fku+vhQ7gx76ruv6Ij4fKZR3l78=";
             };
           in
           combine [


### PR DESCRIPTION
## Summary

- The CI MSRV job is pinned to **1.65.0**, but `cargo generate-lockfile` resolves the latest compatible dependencies — including `tokio-util >= 0.7.14` (needs 1.70) and `tokio >= 1.50` / `tokio-util >= 0.7.17` (need 1.71) — so the MSRV matrix row fails with `package tokio-util ... cannot be built because it requires rustc 1.70 or newer`.
- Separately, `Cargo.toml`'s \`rust-version\` was still \`1.59.0\`, not updated when MSRV was raised to 1.65.0 in 68451a9.

This PR aligns every MSRV reference on **1.71.0**, the highest MSRV currently in the dependency tree. Chosen over 1.70 to future-proof against re-bumping as newer \`tokio\`/\`tokio-util\` versions land.

## Changes

- \`Cargo.toml\` \`rust-version\`: 1.59.0 → 1.71.0
- \`.github/workflows/{linux,macos,windows,code_style}.yml\` MSRV entries: 1.65.0 → 1.71.0
- \`flake.nix\` fenix \`msrvToolchain\` channel: 1.65.0 → 1.71.0 (sha256 recomputed)
- \`README.md\` MSRV line updated

No source code changes — current crate source builds, tests, and is clippy-clean on 1.71.0 as-is.

## Test plan

- [x] \`nix develop --command rustc --version\` → \`rustc 1.71.0\`
- [x] \`nix develop --command cargo check --release --all --bins --examples --tests\` — passes
- [x] \`nix develop --command cargo test --release --all --features "futures_support tokio_support" --no-fail-fast\` — 34 tests pass, 2 ignored (owner-preservation tests that need root)
- [x] \`nix develop --command cargo clippy --features "futures_support tokio_support" --all --tests -- -D clippy::all\` — clean
- [ ] GitHub Actions: Linux / macOS / Windows / code-style (pending CI run)

Note: \`--all-features\` (which enables \`static\`) fails locally because nixpkgs' default \`libarchive\` dev shell doesn't expose \`libb2\`/\`lz4\`/\`zstd\` — unrelated to this change and addressed by #145. The GitHub Actions runners install those libs via apt.