### PR TITLE
docs: update changelog for unreleased changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,16 @@
 
 ## [Unreleased] - ReleaseDate
 
+* Fix partial unfinished archive reads [#133]
+* Add missing `advapi32` link library on Windows builds [#141]
+* flake: add `libb2`, `lz4`, and `zstd` to the development shell [#145]
+* Raise MSRV to 1.82.0 to match dependency tree [#146]
+
+[#133]: https://github.com/OSSystems/compress-tools-rs/pull/133
+[#141]: https://github.com/OSSystems/compress-tools-rs/pull/141
+[#145]: https://github.com/OSSystems/compress-tools-rs/pull/145
+[#146]: https://github.com/OSSystems/compress-tools-rs/pull/146
+
 ## [0.15.1] - 2024-07-16
 
 * Bugfix: unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed isize::MAX [#129]


### PR DESCRIPTION
## Summary

Record the four changes merged to `master` since `v0.15.1` under the `[Unreleased]` section of `CHANGES.md`, following the existing release format.

- #133 — fix partial unfinished archive reads
- #141 — add missing `advapi32` link library on Windows builds
- #145 — flake: add `libb2`, `lz4`, and `zstd` to the development shell
- #146 — raise MSRV to 1.82.0 to match dependency tree

## Test plan

- [x] `CHANGES.md` renders correctly and matches the style of prior entries
- [x] Each referenced PR number has a matching link footnote