### PR TITLE
feat(build): add selective static linking and per-library feature flags

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
-        run: sudo apt-get update; sudo apt-get install libarchive-dev libb2-dev liblz4-dev libacl1-dev libzstd-dev nettle-dev
+        run: sudo apt-get update; sudo apt-get install libarchive-dev libb2-dev liblz4-dev libacl1-dev libzstd-dev liblzma-dev libbz2-dev zlib1g-dev libxml2-dev nettle-dev
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Install Dependencies
-        run: sudo apt-get update; sudo apt-get install libarchive-dev libb2-dev liblz4-dev libacl1-dev libzstd-dev nettle-dev
+        run: sudo apt-get update; sudo apt-get install libarchive-dev libb2-dev liblz4-dev libacl1-dev libzstd-dev liblzma-dev libbz2-dev zlib1g-dev libxml2-dev nettle-dev
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Install stable toolchain (MSRV-aware lockfile resolution)

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,8 +25,16 @@ jobs:
       - name: Install Dependencies
         run: |
           brew install pkgconfig
-          brew install libarchive
-          echo PKG_CONFIG_PATH=$(brew ls libarchive | grep .pc$ | sed 's|/libarchive.pc||') >> $GITHUB_ENV
+          brew install libarchive libb2 lz4 zstd xz bzip2 zlib libxml2
+          # Collect pkg-config dirs for keg-only formulae plus libarchive.
+          PKG_CONFIG_PATHS=""
+          for formula in libarchive bzip2 zlib libxml2; do
+            pcdir="$(brew --prefix "$formula")/lib/pkgconfig"
+            if [ -d "$pcdir" ]; then
+              PKG_CONFIG_PATHS="${PKG_CONFIG_PATHS:+$PKG_CONFIG_PATHS:}$pcdir"
+            fi
+          done
+          echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATHS" >> "$GITHUB_ENV"
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Install stable toolchain (MSRV-aware lockfile resolution)

--- a/.github/workflows/security_check.yml
+++ b/.github/workflows/security_check.yml
@@ -13,6 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install stable toolchain (MSRV-aware lockfile resolution)
+        uses: dtolnay/rust-toolchain@stable
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+        env:
+          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,12 +9,19 @@
 * Propagate `ENOSPC` during archive extraction instead of silently truncating files [#144]
 * flake: add `libb2`, `lz4`, and `zstd` to the development shell [#145]
 * Raise MSRV to 1.82.0 to match dependency tree [#146]
+* Add selective static linking features (`static_b2`, `static_lz4`,
+  `static_zstd`, `static_lzma`, `static_bz2`, `static_z`, `static_xml2`) and
+  make the Windows system imports (`win_user32`, `win_crypt32`, `win_advapi32`,
+  `win_xmllite`) user-selectable; the `static` meta-feature still enables them
+  all. `win_xmllite` also fixes the pre-existing `CreateXmlReader` link error
+  in the Windows static build when libarchive's XAR format is included [#148]
 
 [#133]: https://github.com/OSSystems/compress-tools-rs/pull/133
 [#141]: https://github.com/OSSystems/compress-tools-rs/pull/141
 [#144]: https://github.com/OSSystems/compress-tools-rs/pull/144
 [#145]: https://github.com/OSSystems/compress-tools-rs/pull/145
 [#146]: https://github.com/OSSystems/compress-tools-rs/pull/146
+[#148]: https://github.com/OSSystems/compress-tools-rs/pull/148
 
 ## [0.15.1] - 2024-07-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,34 @@ tokio-util = { version = "0.7.0", features = ["compat"], optional = true }
 libc = "0.2.86"
 
 [features]
+default = ["win_user32", "win_crypt32", "win_advapi32", "win_xmllite"]
 async_support = ["async-trait", "futures-channel", "futures-core", "futures-io", "futures-util", "futures-executor"]
 futures_support = ["async_support", "blocking"]
 tokio_support = ["async_support", "tokio", "tokio-util"]
-static = []
+static = [
+    "static_b2",
+    "static_lz4",
+    "static_zstd",
+    "static_lzma",
+    "static_bz2",
+    "static_z",
+    "static_xml2",
+    "win_user32",
+    "win_crypt32",
+    "win_advapi32",
+    "win_xmllite",
+]
+static_b2 = []
+static_lz4 = []
+static_zstd = []
+static_lzma = []
+static_bz2 = []
+static_z = []
+static_xml2 = []
+win_user32 = []
+win_crypt32 = []
+win_advapi32 = []
+win_xmllite = []
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/src/build.rs
+++ b/src/build.rs
@@ -44,7 +44,17 @@ fn find_libarchive() {
         probe_static("liblzma");
     }
     if cfg!(feature = "static_bz2") {
-        println!("cargo:rustc-link-lib=static=bz2");
+        // bzip2 upstream (and Ubuntu's libbz2-dev) ships no .pc file, but
+        // Homebrew's bzip2 does. Try pkg-config so we pick up search paths on
+        // macOS; fall back to a bare link directive when pkg-config has
+        // nothing, relying on the system library search path.
+        if pkg_config::Config::new()
+            .statik(true)
+            .probe("bzip2")
+            .is_err()
+        {
+            println!("cargo:rustc-link-lib=static=bz2");
+        }
     }
     if cfg!(feature = "static_z") {
         probe_static("zlib");

--- a/src/build.rs
+++ b/src/build.rs
@@ -44,7 +44,7 @@ fn find_libarchive() {
         probe_static("liblzma");
     }
     if cfg!(feature = "static_bz2") {
-        probe_static("bzip2");
+        println!("cargo:rustc-link-lib=static=bz2");
     }
     if cfg!(feature = "static_z") {
         probe_static("zlib");

--- a/src/build.rs
+++ b/src/build.rs
@@ -24,21 +24,33 @@ fn find_libarchive() {
         std::env::set_var("PKG_CONFIG_PATH", MACOS_HOMEBREW_LIBARCHIVE_PATH);
     }
 
-    if cfg!(feature = "static") {
+    let probe_static = |pc_name: &str| {
         pkg_config::Config::new()
-            .statik(cfg!(feature = "static"))
-            .probe("libb2")
-            .expect("Unable to find libb2");
+            .statik(true)
+            .probe(pc_name)
+            .unwrap_or_else(|e| panic!("Unable to find {pc_name}: {e}"));
+    };
 
-        pkg_config::Config::new()
-            .statik(cfg!(feature = "static"))
-            .probe("liblz4")
-            .expect("Unable to find liblz4");
-
-        pkg_config::Config::new()
-            .statik(cfg!(feature = "static"))
-            .probe("libzstd")
-            .expect("Unable to find libzstd");
+    if cfg!(feature = "static_b2") {
+        probe_static("libb2");
+    }
+    if cfg!(feature = "static_lz4") {
+        probe_static("liblz4");
+    }
+    if cfg!(feature = "static_zstd") {
+        probe_static("libzstd");
+    }
+    if cfg!(feature = "static_lzma") {
+        probe_static("liblzma");
+    }
+    if cfg!(feature = "static_bz2") {
+        probe_static("bzip2");
+    }
+    if cfg!(feature = "static_z") {
+        probe_static("zlib");
+    }
+    if cfg!(feature = "static_xml2") {
+        probe_static("libxml-2.0");
     }
 
     pkg_config::Config::new()
@@ -59,7 +71,16 @@ fn find_libarchive() {
         .expect("Unable to find libarchive");
 
     println!("cargo:rustc-link-lib=static=archive");
-    println!("cargo:rustc-link-lib=User32");
-    println!("cargo:rustc-link-lib=Crypt32");
-    println!("cargo:rustc-link-lib=advapi32");
+    if cfg!(feature = "win_user32") {
+        println!("cargo:rustc-link-lib=User32");
+    }
+    if cfg!(feature = "win_crypt32") {
+        println!("cargo:rustc-link-lib=Crypt32");
+    }
+    if cfg!(feature = "win_advapi32") {
+        println!("cargo:rustc-link-lib=advapi32");
+    }
+    if cfg!(feature = "win_xmllite") {
+        println!("cargo:rustc-link-lib=xmllite");
+    }
 }


### PR DESCRIPTION
## Summary

Replaces #140 by rebasing its selective static compilation onto current `master` and extending it with Windows system imports, so callers can opt in to linking individual libraries instead of using the all-or-nothing `static` feature.

- Adds `static_b2`, `static_lz4`, `static_zstd`, `static_lzma`, `static_bz2`, `static_z`, `static_xml2` features that emit `cargo:rustc-link-lib=static=<lib>` when enabled.
- Adds `win_user32`, `win_crypt32`, `win_advapi32` features so the Windows system imports introduced in #141 (`advapi32`) and the existing `User32`/`Crypt32` links can be toggled from the crate user side.
- `static` meta-feature still enables all of the above, preserving its previous meaning.
- Windows imports are listed under `default` features so existing `cargo build` on MSVC targets keeps linking them — this is required because cargo features can't be conditionally defaulted per target.

## Test plan

- [ ] Windows CI passes on this branch (verifies the MSVC import set, including `advapi32`, still links under default features).
- [ ] Linux/macOS CI passes with default features.
- [ ] Linux CI passes with `--features static` (ensures the meta-feature still pulls every selective feature in and the build compiles).
- [ ] Smoke-check that `--no-default-features --features static` builds on MSVC (meta-feature enables `win_*` explicitly).