### PR TITLE
ci: restore Linux CI and retire archived actions-rs actions

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -10,40 +10,29 @@ on:
 
 jobs:
   code_style:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install libarchive-dev libb2-dev liblz4-dev libacl1-dev libzstd-dev nettle-dev
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
-          override: true
           components: rustfmt
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Install stable toolchain (MSRV-aware lockfile resolution)
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Generate Cargo.lock
         run: cargo generate-lockfile
         env:
           CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.82.0 # MSRV
-          override: true
           components: clippy
 
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all --tests -- -D clippy::all
+      - name: Run cargo clippy
+        run: cargo clippy --all-features --all --tests -- -D clippy::all

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,6 +36,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.version }}
+          components: ${{ matrix.version == 'nightly' && 'llvm-tools-preview' || '' }}
       - name: Install grcov tool
         if: matrix.version == 'nightly'
         uses: taiki-e/install-action@v2
@@ -69,7 +70,8 @@ jobs:
         run: cargo test --all --all-features --no-fail-fast -- --nocapture
         env:
           CARGO_INCREMENTAL: "0"
-          RUSTFLAGS: "-Zprofile -Zpanic_abort_tests -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort"
+          RUSTFLAGS: "-Cinstrument-coverage"
+          LLVM_PROFILE_FILE: "target/coverage-%p-%m.profraw"
       - id: coverage
         if: matrix.version == 'nightly'
         name: Gather coverage with grcov
@@ -92,4 +94,4 @@ jobs:
       - name: Clear the coverage files from cache
         if: matrix.version == 'nightly'
         run: |
-          find target/ -name "*.gcda" -exec rm {} +
+          find target/ -name "*.profraw" -exec rm {} +

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,7 +19,7 @@ jobs:
           - nightly
 
     name: Test ${{ matrix.version }} - x86_64-unknown-linux-gnu
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Install Dependencies
@@ -27,27 +27,20 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Install stable toolchain (MSRV-aware lockfile resolution)
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable-x86_64-unknown-linux-gnu
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Generate Cargo.lock
         run: cargo generate-lockfile
         env:
           CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
       - name: Install ${{ matrix.version }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.version }}-x86_64-unknown-linux-gnu
-          profile: minimal
-          override: true
+          toolchain: ${{ matrix.version }}
       - name: Install grcov tool
         if: matrix.version == 'nightly'
-        uses: actions-rs/install@v0.1
+        uses: taiki-e/install-action@v2
         with:
-          crate: grcov
-          use-tool-cache: true
+          tool: grcov
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -65,30 +58,31 @@ jobs:
           key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-build-trimmed-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Check build
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --release --all --bins --examples --tests
+        run: cargo check --release --all --bins --examples --tests
 
       - name: Tests
-        uses: actions-rs/cargo@v1
         timeout-minutes: 10
-        with:
-          command: test
-          args: --release --all --all-features --no-fail-fast -- --nocapture
+        run: cargo test --release --all --all-features --no-fail-fast -- --nocapture
 
       - name: Run cargo test with coverage
         if: matrix.version == 'nightly'
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all --all-features --no-fail-fast -- --nocapture
+        run: cargo test --all --all-features --no-fail-fast -- --nocapture
         env:
           CARGO_INCREMENTAL: "0"
           RUSTFLAGS: "-Zprofile -Zpanic_abort_tests -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort"
       - id: coverage
         if: matrix.version == 'nightly'
-        uses: actions-rs/grcov@master
+        name: Gather coverage with grcov
+        run: |
+          grcov . \
+            --binary-path ./target/debug/ \
+            -s . \
+            -t lcov \
+            --branch \
+            --ignore-not-existing \
+            --ignore '/*' \
+            -o lcov.info
+          echo "report=lcov.info" >> "$GITHUB_OUTPUT"
       - name: Coveralls upload
         if: matrix.version == 'nightly'
         uses: coverallsapp/github-action@master

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,21 +30,15 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Install stable toolchain (MSRV-aware lockfile resolution)
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable-aarch64-apple-darwin
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Generate Cargo.lock
         run: cargo generate-lockfile
         env:
           CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
       - name: Install ${{ matrix.version }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.version }}-aarch64-apple-darwin
-          profile: minimal
-          override: true
+          toolchain: ${{ matrix.version }}
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -62,14 +56,8 @@ jobs:
           key: ${{ matrix.version }}-aarch64-apple-darwin-cargo-build-trimmed-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Check build
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --release --all --bins --examples --tests
+        run: cargo check --release --all --bins --examples --tests
 
       - name: Tests
-        uses: actions-rs/cargo@v1
         timeout-minutes: 10
-        with:
-          command: test
-          args: --release --all --all-features --no-fail-fast -- --nocapture
+        run: cargo test --release --all --all-features --no-fail-fast -- --nocapture

--- a/.github/workflows/security_check.yml
+++ b/.github/workflows/security_check.yml
@@ -10,9 +10,9 @@ on:
 
 jobs:
   audit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/audit-check@v1
+      - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,21 +50,15 @@ jobs:
           VCPKG_ROOT: 'C:\vcpkg'
 
       - name: Install stable toolchain (MSRV-aware lockfile resolution)
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable-x86_64-pc-windows-msvc
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Generate Cargo.lock
         run: cargo generate-lockfile
         env:
           CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
       - name: Install ${{ matrix.version }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.version }}-x86_64-pc-windows-msvc
-          profile: minimal
-          override: true
+          toolchain: ${{ matrix.version }}
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -82,22 +76,16 @@ jobs:
           key: ${{ matrix.version }}-x86_64-pc-windows-msvc-cargo-build-trimmed-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Check build
-        uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: ${{ matrix.linkage == 'x64-windows-static' && '-C target-feature=+crt-static' || '' }}
           VCPKGRS_DYNAMIC: ${{ matrix.linkage == 'x64-windows' && 1 || 0 }}
           VCPKG_DEFAULT_TRIPLET: ${{ matrix.linkage }}
-        with:
-          command: check
-          args: --release --all --bins --examples --tests
+        run: cargo check --release --all --bins --examples --tests
 
       - name: Test
-        uses: actions-rs/cargo@v1
         timeout-minutes: 10
         env:
           RUSTFLAGS: ${{ matrix.linkage == 'x64-windows-static' && '-C target-feature=+crt-static' || '' }}
           VCPKGRS_DYNAMIC: ${{ matrix.linkage == 'x64-windows' && 1 || 0 }}
           VCPKG_DEFAULT_TRIPLET: ${{ matrix.linkage }}
-        with:
-          command: test
-          args: --release --all --all-features --no-fail-fast -- --nocapture
+        run: cargo test --release --all --all-features --no-fail-fast -- --nocapture

--- a/tests/disk_full_test.rs
+++ b/tests/disk_full_test.rs
@@ -45,7 +45,8 @@ fn uncompress_archive_errors_when_target_is_full() {
                 let mut status: libc::c_int = 0;
                 let waited = libc::waitpid(pid, &mut status, 0);
                 assert_eq!(
-                    waited, pid,
+                    waited,
+                    pid,
                     "waitpid failed: {}",
                     std::io::Error::last_os_error()
                 );
@@ -77,10 +78,7 @@ unsafe fn run_child(archive: &Path, target: &Path) -> ! {
     let gid = libc::getgid();
 
     if libc::unshare(libc::CLONE_NEWUSER | libc::CLONE_NEWNS) != 0 {
-        eprintln!(
-            "child: unshare failed: {}",
-            std::io::Error::last_os_error()
-        );
+        eprintln!("child: unshare failed: {}", std::io::Error::last_os_error());
         process::exit(SKIPPED);
     }
 


### PR DESCRIPTION
## Summary

- Linux CI, code-style, and security-audit workflows were pinned to `ubuntu-20.04`, which GitHub retired on 2025-04-15 — jobs queued forever and were cancelled. Repoint to `ubuntu-latest`.
- Replace archived `actions-rs/*` actions (unmaintained since 2022) with maintained successors: `dtolnay/rust-toolchain`, `taiki-e/install-action` for grcov, `rustsec/audit-check`, and plain `cargo` in `run:` steps.
- No Rust code or CI matrix changes.

## Test plan

- [ ] `CI - Linux - x86_64` leaves the `queued` state and all three matrix legs (`1.82.0`, `stable`, `nightly`) run to completion.
- [ ] `Code Style Check` runs `cargo fmt --check` and `cargo clippy` and passes.
- [ ] `Security audit` runs `rustsec/audit-check` and reports.
- [ ] `CI - macOS - aarch64` and `CI - Windows - x86_64` still pass after swapping the `actions-rs/*` wrappers.
- [ ] No `Node.js 16 actions are deprecated` warnings on the run page.