### PR TITLE
keep errno value in Error enum

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,10 @@
   change:** `async_support::list_archive_files`, `uncompress_archive`, and
   `uncompress_archive_file` now require `AsyncRead + AsyncSeek` on the source;
   wrap `tokio::fs::File` via `tokio_util::compat` as needed [#96]
+* **Breaking:** `Error::Extraction` now records the underlying value of
+  `archive_errno` as a `std::io::Error` when available, in addition to the
+  string error message. Match arms for `Error::Extraction(msg)` should be
+  rewritten as `Error::Extraction { details, .. }`. [#151]
 
 [#133]: https://github.com/OSSystems/compress-tools-rs/pull/133
 [#136]: https://github.com/OSSystems/compress-tools-rs/issues/136
@@ -47,6 +51,7 @@
 [#154]: https://github.com/OSSystems/compress-tools-rs/pull/154
 [#158]: https://github.com/OSSystems/compress-tools-rs/pull/158
 [#96]: https://github.com/OSSystems/compress-tools-rs/issues/96
+[#151]: https://github.com/OSSystems/compress-tools-rs/pull/151
 
 ## [0.15.1] - 2024-07-16
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,8 +11,27 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Display, From, Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
-    #[display("Extraction error: '{}'", _0)]
-    Extraction(#[error(not(source))] String),
+    #[display(
+        "Extraction error:{}{} '{}'",
+        match code {
+            Some(_) => " ",
+            None => ""
+        },
+        if let Some(e) = code {
+            e as &dyn std::fmt::Display
+        } else {
+            &"" as &_
+        },
+        details
+    )]
+    Extraction {
+        /// The code stemming from `archive_errno`, unless it is not a valid
+        /// value for `errno(3)`, like `ARCHIVE_ERRNO_MISC`
+        #[error(source)]
+        code: Option<io::Error>,
+        /// The string returned by `archive_error_string`
+        details: String,
+    },
 
     Io(io::Error),
 
@@ -62,20 +81,27 @@ pub(crate) fn archive_result_strict(value: i32, archive: *mut ffi::archive) -> R
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 impl From<*mut ffi::archive> for Error {
     fn from(input: *mut ffi::archive) -> Self {
-        unsafe {
+        let (details, code) = unsafe {
             let error_string = ffi::archive_error_string(input);
-            if !error_string.is_null() {
-                return Error::Extraction(
-                    CStr::from_ptr(error_string).to_string_lossy().to_string(),
-                );
-            }
+            let details = if !error_string.is_null() {
+                Some(CStr::from_ptr(error_string).to_string_lossy().into_owned())
+            } else {
+                None
+            };
 
             let errno = ffi::archive_errno(input);
-            if errno != 0 {
-                return io::Error::from_raw_os_error(errno).into();
-            }
+            let code = if errno > 0 {
+                Some(io::Error::from_raw_os_error(errno))
+            } else {
+                // 0 (unexpected) or ARCHIVE_ERRNO_MISC which is not a valid value of errno(3)
+                None
+            };
+            (details, code)
+        };
+        match (details, code) {
+            (Some(details), code) => Error::Extraction { code, details },
+            (None, Some(code)) => Error::Io(code),
+            (None, None) => Error::Unknown,
         }
-
-        Error::Unknown
     }
 }

--- a/tests/disk_full_test.rs
+++ b/tests/disk_full_test.rs
@@ -18,6 +18,7 @@
 
 use compress_tools::{uncompress_archive, Ownership};
 use std::{
+    error::Error,
     ffi::CString,
     fs::{self, File},
     io::Write,
@@ -134,7 +135,16 @@ unsafe fn run_child(archive: &Path, target: &Path) -> ! {
 
     let result = uncompress_archive(&mut src, target, Ownership::Ignore);
     eprintln!("child: uncompress_archive result = {result:?}");
-    process::exit(if result.is_err() { OK } else { BUG_REPRODUCED });
+    let errno = result.as_ref().err().and_then(|e| {
+        e.source()
+            .and_then(|s| s.downcast_ref::<std::io::Error>())
+            .and_then(std::io::Error::raw_os_error)
+    });
+    process::exit(if errno == Some(libc::ENOSPC) {
+        OK
+    } else {
+        BUG_REPRODUCED
+    });
 }
 
 unsafe fn write_proc(path: &str, content: &str) -> bool {


### PR DESCRIPTION
My goal is to make code calling uncompress_archive able to distinguish No space left on device from other error conditions. This is related to https://github.com/OSSystems/compress-tools-rs/issues/143 .

With this change, the error goes from:

```
thread 'main' (1282548) panicked at src/main.rs:8:63:
called `Result::unwrap()` on an `Err` value: Extraction("Can't create '/tmp/foo/make-4.4.1/NEWS'")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

to

```
thread 'main' (1287751) panicked at src/main.rs:8:63:
called `Result::unwrap()` on an `Err` value: ExtractionIo { code: Os { code: 28, kind: StorageFull, message: "No space left on device" }, details: "Can't create '/tmp/foo/make-4.4.1/NEWS'" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

which is much more explanatory. Besides, calling code can now inspect the cause of the error:
```
if let Err(e) = uncompress_archive(&mut source, &dest, Ownership::Ignore) {
      if let Some(ioerror) =  e.source().and_then(|s| s.downcast_ref::<std::io::Error>()) {
          if ioerror.kind() == std::io::ErrorKind::StorageFull {
              println!("detected storage full")
          }
      }
  }
```

Fixes: https://github.com/OSSystems/compress-tools-rs/issues/143