### PR TITLE
chore(deps): upgrade derive_more to 2.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
   in the Windows static build when libarchive's XAR format is included [#148]
 * Fix incorrect `stat` struct layout on Windows causing corrupted metadata
   (`st_size`, `st_{a,m,c}time`) in `ArchiveIterator` entries [#138]
+* Upgrade `derive_more` from 0.99 to 2.1 and refresh `Cargo.lock` to the
+  latest versions compatible with MSRV 1.82.0 [#154]
 
 [#133]: https://github.com/OSSystems/compress-tools-rs/pull/133
 [#138]: https://github.com/OSSystems/compress-tools-rs/issues/138
@@ -25,6 +27,7 @@
 [#145]: https://github.com/OSSystems/compress-tools-rs/pull/145
 [#146]: https://github.com/OSSystems/compress-tools-rs/pull/146
 [#148]: https://github.com/OSSystems/compress-tools-rs/pull/148
+[#154]: https://github.com/OSSystems/compress-tools-rs/pull/154
 
 ## [0.15.1] - 2024-07-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ all-features = true
 coveralls = { repository = "ossystems/compress-tools-rs" }
 
 [dependencies]
-derive_more = { version = "0.99", default-features = false, features = ["display", "from", "error"] }
+derive_more = { version = "2.1", default-features = false, features = ["std", "display", "from", "error"] }
 async-trait = { version = "0.1.39", optional = true }
 futures-channel = { version = "0.3.5", features = ["sink"], optional = true }
 futures-core = { version = "0.3.5", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,23 +11,23 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Display, From, Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
-    #[display(fmt = "Extraction error: '{}'", _0)]
+    #[display("Extraction error: '{}'", _0)]
     Extraction(#[error(not(source))] String),
 
     Io(io::Error),
 
     Utf(std::str::Utf8Error),
 
-    #[display(fmt = "Encoding error: '{}'", _0)]
+    #[display("Encoding error: '{}'", _0)]
     Encoding(#[error(not(source))] Cow<'static, str>),
 
     #[cfg(feature = "tokio_support")]
     JoinError(tokio::task::JoinError),
 
-    #[display(fmt = "Error to create the archive struct, is null")]
+    #[display("Error to create the archive struct, is null")]
     NullArchive,
 
-    #[display(fmt = "Unknown error")]
+    #[display("Unknown error")]
     Unknown,
 }
 


### PR DESCRIPTION
## Summary

- Bumps `derive_more` from 0.99 to 2.1 (MSRV 1.81, compatible with our 1.82.0).
- Enables the newly required `std` feature (all non-`std` features are disabled by default in 2.x).
- Migrates the `src/error.rs` display attributes from `#[display(fmt = "...")]` to the new `#[display("...")]` syntax.
- Adds a CHANGES.md entry.

## Context

Audit of every direct dependency against MSRV 1.82.0 found `derive_more` as the only direct crate with a major upgrade available that still honors the MSRV. All other direct deps were already at their latest semver-compatible versions. Transitive crates held back by `async-std` (`syn 1.x`, `event-listener 2.x`, `async-channel 1.x`) were left untouched — tracked separately under #153 with a proposed `smol` migration in a follow-up PR.

This supersedes #150 (Dependabot's equivalent bump) — closing that PR is fine once this lands.

## Test plan

- [x] `cargo check` (default features) — clean
- [x] `cargo check --features futures_support,tokio_support` — clean
- [x] `cargo test --features futures_support,tokio_support` — 35 tests + 12 doc-tests pass
- [ ] CI: Linux / Windows / macOS matrix green