### PR TITLE
chore(deps): replace discontinued async-std with smol

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
   (`st_size`, `st_{a,m,c}time`) in `ArchiveIterator` entries [#138]
 * Upgrade `derive_more` from 0.99 to 2.1 and refresh `Cargo.lock` to the
   latest versions compatible with MSRV 1.82.0 [#154]
+* Replace the discontinued `async-std` dev-dependency with `smol` in the
+  `futures_support` example and integration tests (RUSTSEC-2025-0052) [#153]
 
 [#133]: https://github.com/OSSystems/compress-tools-rs/pull/133
 [#138]: https://github.com/OSSystems/compress-tools-rs/issues/138
@@ -27,6 +29,7 @@
 [#145]: https://github.com/OSSystems/compress-tools-rs/pull/145
 [#146]: https://github.com/OSSystems/compress-tools-rs/pull/146
 [#148]: https://github.com/OSSystems/compress-tools-rs/pull/148
+[#153]: https://github.com/OSSystems/compress-tools-rs/issues/153
 [#154]: https://github.com/OSSystems/compress-tools-rs/pull/154
 
 ## [0.15.1] - 2024-07-16

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ win_xmllite = []
 [dev-dependencies]
 tempfile = "3.1"
 argh = "0.1"
-async-std = { version = "1.6.3", features = ["attributes"] }
+smol = "2.0"
 tokio = { version = "1.0.0", features = ["fs", "net"] }
 encoding_rs = "0.8.32"
 

--- a/examples/uncompress_service_futures.rs
+++ b/examples/uncompress_service_futures.rs
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use async_std::net::TcpListener;
 use compress_tools::futures_support::uncompress_data;
+use smol::net::TcpListener;
 
 /// Example usage:
 /// ```
@@ -11,13 +11,17 @@ use compress_tools::futures_support::uncompress_data;
 /// some_file_content
 /// ```
 
-#[async_std::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let listener = TcpListener::bind("127.0.0.1:1234").await?;
-    loop {
-        let (socket, _) = listener.accept().await?;
-        async_std::task::spawn(async move {
-            println!("{:?}", uncompress_data(&socket, &socket).await);
-        });
-    }
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    smol::block_on(async {
+        let listener = TcpListener::bind("127.0.0.1:1234").await?;
+        loop {
+            let (socket, _) = listener.accept().await?;
+            smol::spawn(async move {
+                let mut reader = socket.clone();
+                let mut writer = socket;
+                println!("{:?}", uncompress_data(&mut reader, &mut writer).await);
+            })
+            .detach();
+        }
+    })
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -24,23 +24,25 @@ fn get_compressed_file_content() {
     assert_eq!(written, 18, "Uncompressed bytes count did not match");
 }
 
-#[async_std::test]
+#[test]
 #[cfg(feature = "futures_support")]
-async fn get_compressed_file_content_futures() {
-    let mut source = async_std::fs::File::open("tests/fixtures/file.txt.gz")
-        .await
-        .unwrap();
-    let mut target = Vec::default();
+fn get_compressed_file_content_futures() {
+    smol::block_on(async {
+        let mut source = smol::fs::File::open("tests/fixtures/file.txt.gz")
+            .await
+            .unwrap();
+        let mut target = Vec::default();
 
-    let written = futures_support::uncompress_data(&mut source, &mut target)
-        .await
-        .expect("Failed to uncompress the file");
-    assert_eq!(
-        String::from_utf8_lossy(&target),
-        "some_file_content\n",
-        "Uncompressed file did not match",
-    );
-    assert_eq!(written, 18, "Uncompressed bytes count did not match");
+        let written = futures_support::uncompress_data(&mut source, &mut target)
+            .await
+            .expect("Failed to uncompress the file");
+        assert_eq!(
+            String::from_utf8_lossy(&target),
+            "some_file_content\n",
+            "Uncompressed file did not match",
+        );
+        assert_eq!(written, 18, "Uncompressed bytes count did not match");
+    });
 }
 
 #[tokio::test]
@@ -92,24 +94,26 @@ fn get_a_file_from_7z() {
     assert_eq!(written, 14, "Uncompressed bytes count did not match");
 }
 
-#[async_std::test]
+#[test]
 #[cfg(feature = "futures_support")]
-async fn get_a_file_from_tar_futures() {
-    let mut source = async_std::fs::File::open("tests/fixtures/tree.tar")
-        .await
-        .unwrap();
-    let mut target = Vec::default();
-
-    let written =
-        futures_support::uncompress_archive_file(&mut source, &mut target, "tree/branch2/leaf")
+fn get_a_file_from_tar_futures() {
+    smol::block_on(async {
+        let mut source = smol::fs::File::open("tests/fixtures/tree.tar")
             .await
-            .expect("Failed to get the file");
-    assert_eq!(
-        String::from_utf8_lossy(&target),
-        "Goodbye World\n",
-        "Uncompressed file did not match",
-    );
-    assert_eq!(written, 14, "Uncompressed bytes count did not match");
+            .unwrap();
+        let mut target = Vec::default();
+
+        let written =
+            futures_support::uncompress_archive_file(&mut source, &mut target, "tree/branch2/leaf")
+                .await
+                .expect("Failed to get the file");
+        assert_eq!(
+            String::from_utf8_lossy(&target),
+            "Goodbye World\n",
+            "Uncompressed file did not match",
+        );
+        assert_eq!(written, 14, "Uncompressed bytes count did not match");
+    });
 }
 
 #[tokio::test]
@@ -149,24 +153,26 @@ fn successfully_list_archive_files() {
     );
 }
 
-#[async_std::test]
+#[test]
 #[cfg(feature = "futures_support")]
-async fn successfully_list_archive_files_futures() {
-    let source = async_std::fs::File::open("tests/fixtures/tree.tar")
-        .await
-        .unwrap();
+fn successfully_list_archive_files_futures() {
+    smol::block_on(async {
+        let source = smol::fs::File::open("tests/fixtures/tree.tar")
+            .await
+            .unwrap();
 
-    assert_eq!(
-        futures_support::list_archive_files(source).await.unwrap(),
-        vec![
-            "tree/".to_string(),
-            "tree/branch1/".to_string(),
-            "tree/branch1/leaf".to_string(),
-            "tree/branch2/".to_string(),
-            "tree/branch2/leaf".to_string(),
-        ],
-        "file list inside the archive did not match"
-    );
+        assert_eq!(
+            futures_support::list_archive_files(source).await.unwrap(),
+            vec![
+                "tree/".to_string(),
+                "tree/branch1/".to_string(),
+                "tree/branch1/leaf".to_string(),
+                "tree/branch2/".to_string(),
+                "tree/branch2/leaf".to_string(),
+            ],
+            "file list inside the archive did not match"
+        );
+    });
 }
 
 #[tokio::test]
@@ -429,31 +435,33 @@ fn uncompress_same_file_not_preserve_owner() {
     .expect("Failed to uncompress the file");
 }
 
-#[async_std::test]
+#[test]
 #[cfg(feature = "futures_support")]
-async fn uncompress_same_file_not_preserve_owner_futures() {
-    futures_support::uncompress_archive(
-        &mut async_std::fs::File::open("tests/fixtures/tree.tar")
-            .await
-            .unwrap(),
-        tempfile::TempDir::new()
-            .expect("Failed to create the tmp directory")
-            .path(),
-        Ownership::Ignore,
-    )
-    .await
-    .expect("Failed to uncompress the file");
-    futures_support::uncompress_archive(
-        &mut async_std::fs::File::open("tests/fixtures/tree.tar")
-            .await
-            .unwrap(),
-        tempfile::TempDir::new()
-            .expect("Failed to create the tmp directory")
-            .path(),
-        Ownership::Ignore,
-    )
-    .await
-    .expect("Failed to uncompress the file");
+fn uncompress_same_file_not_preserve_owner_futures() {
+    smol::block_on(async {
+        futures_support::uncompress_archive(
+            &mut smol::fs::File::open("tests/fixtures/tree.tar")
+                .await
+                .unwrap(),
+            tempfile::TempDir::new()
+                .expect("Failed to create the tmp directory")
+                .path(),
+            Ownership::Ignore,
+        )
+        .await
+        .expect("Failed to uncompress the file");
+        futures_support::uncompress_archive(
+            &mut smol::fs::File::open("tests/fixtures/tree.tar")
+                .await
+                .unwrap(),
+            tempfile::TempDir::new()
+                .expect("Failed to create the tmp directory")
+                .path(),
+            Ownership::Ignore,
+        )
+        .await
+        .expect("Failed to uncompress the file");
+    });
 }
 
 #[tokio::test]
@@ -494,19 +502,21 @@ fn uncompress_truncated_archive() {
     ));
 }
 
-#[async_std::test]
+#[test]
 #[cfg(feature = "futures_support")]
-async fn uncompress_truncated_archive_futures() {
-    assert!(matches!(
-        futures_support::uncompress_data(
-            async_std::fs::File::open("tests/fixtures/truncated.log.gz")
-                .await
-                .unwrap(),
-            Vec::new()
-        )
-        .await,
-        Err(Error::Unknown)
-    ));
+fn uncompress_truncated_archive_futures() {
+    smol::block_on(async {
+        assert!(matches!(
+            futures_support::uncompress_data(
+                smol::fs::File::open("tests/fixtures/truncated.log.gz")
+                    .await
+                    .unwrap(),
+                Vec::new()
+            )
+            .await,
+            Err(Error::Unknown)
+        ));
+    });
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Replaces the discontinued `async-std` dev-dependency (flagged by [RUSTSEC-2025-0052](https://rustsec.org/advisories/RUSTSEC-2025-0052.html)) with `smol = "2.0"`, its maintained successor from the same ecosystem.
- `async-std` was only used in the `futures_support` example and integration tests — the library itself never depended on it, so downstream users are unaffected.
- Ports `examples/uncompress_service_futures.rs` to `smol::block_on` + `smol::net::TcpListener`, and swaps `#[async_std::test]` for `#[test]` wrapping `smol::block_on(async { ... })` with `smol::fs::File` in `tests/integration_test.rs`.

Note: smol's `TcpStream` doesn't implement `AsyncRead`/`AsyncWrite` through a shared reference (async-std's did), so the example clones the socket for the reader/writer pair.

Cargo.lock is gitignored and CI uses `CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback`, so the MSRV-compatible `async-signal 0.2.13` is selected automatically (0.2.14 requires rustc 1.85, above our 1.82 MSRV).

Closes #153

## Test plan

- [x] `cargo build --features futures_support --example uncompress_service_futures`
- [x] `cargo test --features "futures_support tokio_support"` — 35/35 integration tests pass
- [ ] CI green on Linux / macOS / Windows at MSRV 1.82 and stable
- [ ] `cargo audit` no longer flags RUSTSEC-2025-0052