### PR TITLE
ci(deps): bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install libarchive-dev libb2-dev liblz4-dev libacl1-dev libzstd-dev liblzma-dev libbz2-dev zlib1g-dev libxml2-dev nettle-dev
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install libarchive-dev libb2-dev liblz4-dev libacl1-dev libzstd-dev liblzma-dev libbz2-dev zlib1g-dev libxml2-dev nettle-dev
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install stable toolchain (MSRV-aware lockfile resolution)
         uses: dtolnay/rust-toolchain@stable
       - name: Generate Cargo.lock
@@ -43,17 +43,17 @@ jobs:
         with:
           tool: grcov
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/registry
           key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-registry-trimmed-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo index
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/git
           key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-index-trimmed-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-build-trimmed-${{ hashFiles('**/Cargo.lock') }}
@@ -87,10 +87,10 @@ jobs:
           echo "report=lcov.info" >> "$GITHUB_OUTPUT"
       - name: Coveralls upload
         if: matrix.version == 'nightly'
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ${{ steps.coverage.outputs.report }}
+          file: ${{ steps.coverage.outputs.report }}
       - name: Clear the coverage files from cache
         if: matrix.version == 'nightly'
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,7 +36,7 @@ jobs:
           done
           echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATHS" >> "$GITHUB_ENV"
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install stable toolchain (MSRV-aware lockfile resolution)
         uses: dtolnay/rust-toolchain@stable
       - name: Generate Cargo.lock
@@ -48,17 +48,17 @@ jobs:
         with:
           toolchain: ${{ matrix.version }}
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/registry
           key: ${{ matrix.version }}-aarch64-apple-darwin-cargo-registry-trimmed-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo index
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/git
           key: ${{ matrix.version }}-aarch64-apple-darwin-cargo-index-trimmed-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ${{ matrix.version }}-aarch64-apple-darwin-cargo-build-trimmed-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/security_check.yml
+++ b/.github/workflows/security_check.yml
@@ -12,7 +12,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install stable toolchain (MSRV-aware lockfile resolution)
         uses: dtolnay/rust-toolchain@stable
       - name: Generate Cargo.lock

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache vcpkg installed
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: $VCPKG_ROOT/installed
           key: ${{ runner.os }}-vcpkg-cache-${{ matrix.linkage }}
@@ -37,7 +37,7 @@ jobs:
           VCPKG_ROOT: 'C:\vcpkg'
 
       - name: Cache vcpkg downloads
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: $VCPKG_ROOT/downloads
           key: ${{ runner.os }}-vcpkg-cache-${{ matrix.linkage }}
@@ -60,17 +60,17 @@ jobs:
         with:
           toolchain: ${{ matrix.version }}
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/registry
           key: ${{ matrix.version }}-x86_64-pc-windows-msvc-cargo-registry-trimmed-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo index
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/git
           key: ${{ matrix.version }}-x86_64-pc-windows-msvc-cargo-index-trimmed-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ${{ matrix.version }}-x86_64-pc-windows-msvc-cargo-build-trimmed-${{ hashFiles('**/Cargo.lock') }}


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v4 to v6 across all workflows
- Bump `actions/cache` from v4 to v5 across linux/macos/windows workflows
- Pin `coverallsapp/github-action` to v2 (was tracking `master`) and rename `path-to-lcov` input to `file` per the v2 API

## Test plan
- [ ] Linux CI passes across MSRV/stable/nightly
- [ ] macOS CI passes across MSRV/stable/nightly
- [ ] Windows CI passes across all matrix combinations
- [ ] Coveralls upload from the nightly Linux job still reports coverage
- [ ] Security audit workflow runs successfully
- [ ] Code style workflow runs successfully