### PR TITLE
fix: auto-rewind source reader on seekable entry points

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased] - ReleaseDate
 
+* Rewind the source reader at the start of every seekable entry point
+  (`list_archive_files`, `list_archive_entries`, `uncompress_archive`,
+  `uncompress_archive_file`, `ArchiveIterator`, and their `_with_encoding`
+  variants), so callers can reuse the same reader across successive calls
+  without a manual `seek(SeekFrom::Start(0))` between them [#117]
 * Fix RAR extraction failing with "Can't decompress an entry marked as a
   directory" whenever the archive contains directory entries. Data reads are
   now skipped for directory entries in `uncompress_archive`,

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -180,6 +180,8 @@ impl<R: Read + Seek> ArchiveIterator<R> {
         R: Read + Seek,
     {
         let utf8_guard = ffi::UTF8LocaleGuard::new();
+        // libarchive only sniffs the format from offset 0.
+        source.seek(SeekFrom::Start(0))?;
         crate::zip_preflight::reject_unsupported_zip_methods(&mut source)?;
         let reader = source;
         let buffer = [0; READER_BUFFER_SIZE];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -512,6 +512,8 @@ where
     R: Read + Seek,
 {
     let _utf8_guard = ffi::UTF8LocaleGuard::new();
+    // libarchive only sniffs the format from offset 0.
+    reader.seek(SeekFrom::Start(0))?;
     zip_preflight::reject_unsupported_zip_methods(&mut reader)?;
     unsafe {
         let archive_entry: *mut ffi::archive_entry = std::ptr::null_mut();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -154,6 +154,33 @@ fn successfully_list_archive_files() {
 }
 
 #[test]
+fn reader_is_rewound_between_calls() {
+    let mut source = std::fs::File::open("tests/fixtures/tree.tar").unwrap();
+
+    let listed = list_archive_files(&mut source).unwrap();
+    assert!(listed.contains(&"tree/branch2/leaf".to_string()));
+
+    let mut target = Vec::new();
+    let written = uncompress_archive_file(&mut source, &mut target, "tree/branch2/leaf")
+        .expect("extract should succeed even though the reader was left past the archive");
+    assert_eq!(written, 14);
+    assert_eq!(String::from_utf8_lossy(&target), "Goodbye World\n");
+
+    let listed_again = list_archive_files(&mut source).unwrap();
+    assert_eq!(listed, listed_again);
+
+    let names: Vec<String> = ArchiveIteratorBuilder::new(&mut source)
+        .build()
+        .unwrap()
+        .filter_map(|c| match c {
+            ArchiveContents::StartOfEntry(name, _) => Some(name),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(names, listed);
+}
+
+#[test]
 fn successfully_list_archive_entries() {
     let source = std::fs::File::open("tests/fixtures/tree.tar").unwrap();
 


### PR DESCRIPTION
## Summary
- Seek the source reader to offset 0 at the top of `run_with_archive` (sync path) and `ArchiveIterator::new` (iterator path), so callers can reuse the same `Read + Seek` reader across successive `list_archive_files` / `uncompress_archive_file` / `ArchiveIterator` calls without a manual rewind.
- Previously, forgetting the manual `seek(SeekFrom::Start(0))` between calls surfaced as an opaque "unrecognized format" error, because libarchive only sniffs the format from byte 0.
- Changelog entry + regression test covering list → extract → list → iterate on a single file handle.

Closes #117.

## Test plan
- [x] `cargo test` (39 integration + 14 doc tests pass)
- [x] New `reader_is_rewound_between_calls` test exercises the list → extract → list → iterate sequence on one reader