### PR TITLE
Reject non-archive inputs on archive entry points (#77)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,9 +9,12 @@
   `uncompress_archive`, `uncompress_archive_file`, `ArchiveIterator`, and
   their `_with_encoding` and async variants now return an error for input
   that isn't a real archive, instead of treating it as a single-entry
-  archive named `data`. `uncompress_data` still supports raw streams
-  (that is its purpose). Callers that want the old iterator behavior can
-  opt back in with `ArchiveIteratorBuilder::raw_format(true)` [#77]
+  archive named `data`. `uncompress_data` still supports raw streams (that
+  is its purpose). Callers that want the old iterator behavior for
+  non-archive bytes can opt back in with
+  `ArchiveIteratorBuilder::raw_format(true)`. Callers iterating with
+  `ArchiveIterator` can additionally opt out of libarchive's permissive
+  mtree matching with `ArchiveIteratorBuilder::mtree_format(false)` [#77]
 * Rewind the source reader at the start of every seekable entry point
   (`list_archive_files`, `list_archive_entries`, `uncompress_archive`,
   `uncompress_archive_file`, `ArchiveIterator`, and their `_with_encoding`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased] - ReleaseDate
 
+* **Breaking:** libarchive's "raw" format handler is no longer registered on
+  the archive code paths. `list_archive_files`, `list_archive_entries`,
+  `uncompress_archive`, `uncompress_archive_file`, `ArchiveIterator`, and
+  their `_with_encoding` and async variants now return an error for input
+  that isn't a real archive, instead of treating it as a single-entry
+  archive named `data`. `uncompress_data` still supports raw streams
+  (that is its purpose). Callers that want the old iterator behavior can
+  opt back in with `ArchiveIteratorBuilder::raw_format(true)` [#77]
 * Rewind the source reader at the start of every seekable entry point
   (`list_archive_files`, `list_archive_entries`, `uncompress_archive`,
   `uncompress_archive_file`, `ArchiveIterator`, and their `_with_encoding`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compress-tools"
-version = "0.15.1"
+version = "0.16.0"
 authors = ["Jonathas-Conceicao <jadoliveira@inf.ufpel.edu.br>"]
 description = "Utility functions for compressed and archive files handling"
 repository = "https://github.com/OSSystems/compress-tools-rs"

--- a/scripts/generate-ffi
+++ b/scripts/generate-ffi
@@ -40,6 +40,9 @@ bindgen \
     --allowlist-var "ARCHIVE_EXTRACT_OWNER" \
     --allowlist-var "ARCHIVE_EXTRACT_FFLAGS" \
     --allowlist-var "ARCHIVE_EXTRACT_XATTR" \
+    --allowlist-var "ARCHIVE_FORMAT_BASE_MASK" \
+    --allowlist-var "ARCHIVE_FORMAT_MTREE" \
+    --allowlist-function "archive_format" \
     --allowlist-function "archive_read_new" \
     --allowlist-function "archive_read_set_seek_callback" \
     --allowlist-function "archive_read_support_filter_all" \

--- a/src/ffi/generated.rs
+++ b/src/ffi/generated.rs
@@ -15,6 +15,8 @@ pub(crate) const ARCHIVE_EXTRACT_TIME: u32 = 4;
 pub(crate) const ARCHIVE_EXTRACT_ACL: u32 = 32;
 pub(crate) const ARCHIVE_EXTRACT_FFLAGS: u32 = 64;
 pub(crate) const ARCHIVE_EXTRACT_XATTR: u32 = 128;
+pub(crate) const ARCHIVE_FORMAT_BASE_MASK: ::std::os::raw::c_int = 0xff0000;
+pub(crate) const ARCHIVE_FORMAT_MTREE: ::std::os::raw::c_int = 0x80000;
 pub(crate) type __dev_t = ::std::os::raw::c_ulong;
 pub(crate) type __uid_t = ::std::os::raw::c_uint;
 pub(crate) type __gid_t = ::std::os::raw::c_uint;
@@ -157,6 +159,9 @@ extern "C" {
 }
 extern "C" {
     pub(crate) fn archive_errno(arg1: *mut archive) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub(crate) fn archive_format(arg1: *mut archive) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub(crate) fn archive_error_string(arg1: *mut archive) -> *const ::std::os::raw::c_char;

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -175,6 +175,7 @@ impl<R: Read + Seek> ArchiveIterator<R> {
         decode: DecodeCallback,
         filter: Option<Box<EntryFilterCallbackFn>>,
         password: Option<ArchivePassword>,
+        raw_format: bool,
     ) -> Result<ArchiveIterator<R>>
     where
         R: Read + Seek,
@@ -204,10 +205,12 @@ impl<R: Read + Seek> ArchiveIterator<R> {
                     archive_reader,
                 )?;
 
-                archive_result(
-                    ffi::archive_read_support_format_raw(archive_reader),
-                    archive_reader,
-                )?;
+                if raw_format {
+                    archive_result(
+                        ffi::archive_read_support_format_raw(archive_reader),
+                        archive_reader,
+                    )?;
+                }
 
                 archive_result(
                     ffi::archive_read_set_seek_callback(
@@ -304,7 +307,7 @@ impl<R: Read + Seek> ArchiveIterator<R> {
     where
         R: Read + Seek,
     {
-        Self::new(source, decode, None, None)
+        Self::new(source, decode, None, None, false)
     }
 
     /// Iterate over the contents of an archive, streaming the contents of each
@@ -343,7 +346,7 @@ impl<R: Read + Seek> ArchiveIterator<R> {
     where
         R: Read + Seek,
     {
-        Self::new(source, crate::decode_utf8, None, None)
+        Self::new(source, crate::decode_utf8, None, None, false)
     }
 
     /// Close the iterator, freeing up the associated resources.
@@ -479,6 +482,7 @@ where
     decoder: DecodeCallback,
     filter: Option<Box<EntryFilterCallbackFn>>,
     password: Option<ArchivePassword>,
+    raw_format: bool,
 }
 
 /// A builder to generate an archive iterator over the contents of an
@@ -518,6 +522,7 @@ where
             decoder: crate::decode_utf8,
             filter: None,
             password: None,
+            raw_format: false,
         }
     }
 
@@ -544,8 +549,25 @@ where
         self
     }
 
+    /// Enable libarchive's "raw" format handler, which parses any byte
+    /// stream as a single-entry archive with pathname `data`.
+    ///
+    /// Disabled by default so the iterator rejects input that isn't a real
+    /// archive. Enable it only when you intentionally want to iterate over
+    /// arbitrary non-archive streams (e.g. a standalone gzip file).
+    pub fn raw_format(mut self, enable: bool) -> ArchiveIteratorBuilder<R> {
+        self.raw_format = enable;
+        self
+    }
+
     /// Finish the builder and generate the configured `ArchiveIterator`.
     pub fn build(self) -> Result<ArchiveIterator<R>> {
-        ArchiveIterator::new(self.source, self.decoder, self.filter, self.password)
+        ArchiveIterator::new(
+            self.source,
+            self.decoder,
+            self.filter,
+            self.password,
+            self.raw_format,
+        )
     }
 }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -79,6 +79,7 @@ pub struct ArchiveIterator<R: Read + Seek> {
     current_is_dir: bool,
     closed: bool,
     error: bool,
+    mtree_format: bool,
     filter: Option<Box<EntryFilterCallbackFn>>,
 
     _pipe: Box<HeapReadSeekerPipe<R>>,
@@ -176,6 +177,7 @@ impl<R: Read + Seek> ArchiveIterator<R> {
         filter: Option<Box<EntryFilterCallbackFn>>,
         password: Option<ArchivePassword>,
         raw_format: bool,
+        mtree_format: bool,
     ) -> Result<ArchiveIterator<R>>
     where
         R: Read + Seek,
@@ -252,6 +254,7 @@ impl<R: Read + Seek> ArchiveIterator<R> {
                 current_is_dir: false,
                 closed: false,
                 error: false,
+                mtree_format,
                 filter,
 
                 _pipe: pipe,
@@ -307,7 +310,7 @@ impl<R: Read + Seek> ArchiveIterator<R> {
     where
         R: Read + Seek,
     {
-        Self::new(source, decode, None, None, false)
+        Self::new(source, decode, None, None, false, true)
     }
 
     /// Iterate over the contents of an archive, streaming the contents of each
@@ -346,7 +349,7 @@ impl<R: Read + Seek> ArchiveIterator<R> {
     where
         R: Read + Seek,
     {
-        Self::new(source, crate::decode_utf8, None, None, false)
+        Self::new(source, crate::decode_utf8, None, None, false, true)
     }
 
     /// Close the iterator, freeing up the associated resources.
@@ -380,6 +383,11 @@ impl<R: Read + Seek> ArchiveIterator<R> {
         match ffi::archive_read_next_header(self.archive_reader, &mut self.archive_entry) {
             ffi::ARCHIVE_EOF => ArchiveContents::EndOfEntry,
             ffi::ARCHIVE_OK | ffi::ARCHIVE_WARN => {
+                if !self.mtree_format {
+                    if let Err(e) = reject_mtree_format(self.archive_reader) {
+                        return ArchiveContents::Err(e);
+                    }
+                }
                 let _utf8_guard = ffi::WindowsUTF8LocaleGuard::new();
                 let cstr = CStr::from_ptr(ffi::archive_entry_pathname(self.archive_entry));
                 let file_name = match (self.decode)(cstr.to_bytes()) {
@@ -426,6 +434,20 @@ impl<R: Read + Seek> ArchiveIterator<R> {
             _ => ArchiveContents::Err(Error::from(self.archive_reader)),
         }
     }
+}
+
+// Must be called after a successful `archive_read_next_header`, since
+// libarchive only populates the format code once a header has been read.
+unsafe fn reject_mtree_format(archive_reader: *mut ffi::archive) -> Result<()> {
+    if ffi::archive_format(archive_reader) & ffi::ARCHIVE_FORMAT_BASE_MASK
+        == ffi::ARCHIVE_FORMAT_MTREE
+    {
+        return Err(Error::Extraction {
+            code: None,
+            details: "mtree specifications are not treated as archives".to_string(),
+        });
+    }
+    Ok(())
 }
 
 unsafe extern "C" fn libarchive_heap_seek_callback<R: Read + Seek>(
@@ -483,6 +505,7 @@ where
     filter: Option<Box<EntryFilterCallbackFn>>,
     password: Option<ArchivePassword>,
     raw_format: bool,
+    mtree_format: bool,
 }
 
 /// A builder to generate an archive iterator over the contents of an
@@ -523,6 +546,7 @@ where
             filter: None,
             password: None,
             raw_format: false,
+            mtree_format: true,
         }
     }
 
@@ -560,6 +584,16 @@ where
         self
     }
 
+    /// Accept entries from libarchive's "mtree" format handler (default).
+    ///
+    /// libarchive's mtree parser is permissive and will match free-form
+    /// text (a plain gunzip'd text file is enough); pass `false` to
+    /// reject those matches and error out instead.
+    pub fn mtree_format(mut self, enable: bool) -> ArchiveIteratorBuilder<R> {
+        self.mtree_format = enable;
+        self
+    }
+
     /// Finish the builder and generate the configured `ArchiveIterator`.
     pub fn build(self) -> Result<ArchiveIterator<R>> {
         ArchiveIterator::new(
@@ -568,6 +602,7 @@ where
             self.filter,
             self.password,
             self.raw_format,
+            self.mtree_format,
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,15 +52,16 @@
 //! Archive-listing and archive-extraction entry points (`list_archive_files`,
 //! `list_archive_entries`, `uncompress_archive`, `uncompress_archive_file`,
 //! `ArchiveIterator`, and their async/`_with_encoding` siblings) no longer
-//! register libarchive's "raw" format handler. They return an error for
-//! input that isn't a real archive instead of yielding a single entry
-//! called `data`, so callers can reliably distinguish archives from other
-//! files.
+//! register libarchive's "raw" format handler, so input that isn't a real
+//! archive errors out instead of yielding a single `data` entry.
 //!
 //! Use [`uncompress_data`] for decompressing a single stream (gzip, xz, …)
 //! — it continues to support raw input because that is its purpose. For
 //! streaming iteration that should accept arbitrary bytes, opt back in
-//! with [`ArchiveIteratorBuilder::raw_format`].
+//! with [`ArchiveIteratorBuilder::raw_format`]. libarchive's "mtree"
+//! handler remains enabled on all entry points; pass
+//! `ArchiveIteratorBuilder::mtree_format(false)` to the iterator if you
+//! need to reject mtree matches.
 
 #[cfg(feature = "async_support")]
 pub mod async_support;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,21 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! # Strict archive parsing
+//!
+//! Archive-listing and archive-extraction entry points (`list_archive_files`,
+//! `list_archive_entries`, `uncompress_archive`, `uncompress_archive_file`,
+//! `ArchiveIterator`, and their async/`_with_encoding` siblings) no longer
+//! register libarchive's "raw" format handler. They return an error for
+//! input that isn't a real archive instead of yielding a single entry
+//! called `data`, so callers can reliably distinguish archives from other
+//! files.
+//!
+//! Use [`uncompress_data`] for decompressing a single stream (gzip, xz, …)
+//! — it continues to support raw input because that is its purpose. For
+//! streaming iteration that should accept arbitrary bytes, opt back in
+//! with [`ArchiveIteratorBuilder::raw_format`].
 
 #[cfg(feature = "async_support")]
 pub mod async_support;
@@ -523,11 +538,6 @@ where
         let res = (|| {
             archive_result(
                 ffi::archive_read_support_filter_all(archive_reader),
-                archive_reader,
-            )?;
-
-            archive_result(
-                ffi::archive_read_support_format_raw(archive_reader),
                 archive_reader,
             )?;
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1408,11 +1408,29 @@ fn iterator_default_rejects_non_archive_bytes() {
     let source = Cursor::new(NON_ARCHIVE_BYTES);
     let saw_err = match ArchiveIterator::from_read(source) {
         Err(_) => true,
-        Ok(iter) => iter.into_iter().any(|c| matches!(c, ArchiveContents::Err(_))),
+        Ok(iter) => iter
+            .into_iter()
+            .any(|c| matches!(c, ArchiveContents::Err(_))),
     };
     assert!(
         saw_err,
         "strict iterator must surface an error on non-archive input"
+    );
+}
+
+#[test]
+fn iterator_mtree_format_opt_out_rejects_gzip_text() {
+    let source = std::fs::File::open("tests/fixtures/file.txt.gz").unwrap();
+    let saw_err = match ArchiveIteratorBuilder::new(source)
+        .mtree_format(false)
+        .build()
+    {
+        Err(_) => true,
+        Ok(mut iter) => iter.any(|c| matches!(c, ArchiveContents::Err(_))),
+    };
+    assert!(
+        saw_err,
+        "mtree_format(false) must reject libarchive's permissive mtree match on plain text"
     );
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1064,7 +1064,11 @@ fn iterate_zip_with_cjk_pathname() {
 fn iterate_truncated_archive() {
     let source = std::fs::File::open("tests/fixtures/truncated.log.gz").unwrap();
 
-    for content in ArchiveIterator::from_read(source).unwrap() {
+    for content in ArchiveIteratorBuilder::new(source)
+        .raw_format(true)
+        .build()
+        .unwrap()
+    {
         if let ArchiveContents::Err(Error::Unknown) = content {
             return;
         }
@@ -1076,7 +1080,11 @@ fn iterate_truncated_archive() {
 fn uncompress_bytes_helper(bytes: &[u8]) {
     let wrapper = Cursor::new(bytes);
 
-    for content in ArchiveIterator::from_read(wrapper).unwrap() {
+    for content in ArchiveIteratorBuilder::new(wrapper)
+        .raw_format(true)
+        .build()
+        .unwrap()
+    {
         if let ArchiveContents::Err(Error::Unknown) = content {
             return;
         }
@@ -1128,7 +1136,7 @@ fn uncompress_archive_absolute_path() {
 
 #[test]
 fn decode_failure() {
-    let source = std::fs::File::open("tests/fixtures/file.txt.gz").unwrap();
+    let source = std::fs::File::open("tests/fixtures/tree.tar").unwrap();
     let decode_fail = |_bytes: &[u8]| Err(Error::Io(std::io::Error::from(ErrorKind::BrokenPipe)));
 
     for content in ArchiveIterator::from_read_with_encoding(source, decode_fail).unwrap() {
@@ -1370,4 +1378,56 @@ fn archive_password_with_nul_byte_rejected() {
         ArchivePassword::new("abc\0def").is_err(),
         "passwords containing NUL must be rejected, not panic",
     );
+}
+
+// Arbitrary binary blob that matches no libarchive format handler. Used to
+// prove the "raw" handler is the thing making this parseable: strict mode
+// errors, raw_format(true) accepts it as a single "data" entry.
+const NON_ARCHIVE_BYTES: &[u8] = &[
+    0x00, 0x01, 0x02, 0x03, 0xff, 0xfe, 0xfd, 0xfc, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80,
+];
+
+#[test]
+fn list_archive_files_rejects_non_archive_bytes() {
+    let source = Cursor::new(NON_ARCHIVE_BYTES);
+    assert!(
+        list_archive_files(source).is_err(),
+        "arbitrary bytes must no longer be listed as a single \"data\" entry",
+    );
+}
+
+#[test]
+fn uncompress_archive_rejects_non_archive_bytes() {
+    let source = Cursor::new(NON_ARCHIVE_BYTES);
+    let dir = tempfile::TempDir::new().unwrap();
+    assert!(uncompress_archive(source, dir.path(), Ownership::Ignore).is_err());
+}
+
+#[test]
+fn iterator_default_rejects_non_archive_bytes() {
+    let source = Cursor::new(NON_ARCHIVE_BYTES);
+    let saw_err = match ArchiveIterator::from_read(source) {
+        Err(_) => true,
+        Ok(iter) => iter.into_iter().any(|c| matches!(c, ArchiveContents::Err(_))),
+    };
+    assert!(
+        saw_err,
+        "strict iterator must surface an error on non-archive input"
+    );
+}
+
+#[test]
+fn iterator_raw_format_opt_in_accepts_non_archive_bytes() {
+    let source = Cursor::new(NON_ARCHIVE_BYTES);
+    let mut names = Vec::new();
+    for content in ArchiveIteratorBuilder::new(source)
+        .raw_format(true)
+        .build()
+        .expect("raw_format(true) should accept arbitrary bytes")
+    {
+        if let ArchiveContents::StartOfEntry(name, _) = content {
+            names.push(name);
+        }
+    }
+    assert_eq!(names, vec!["data".to_string()]);
 }


### PR DESCRIPTION
## Summary
- Closes #77. libarchive's "raw" format handler matches arbitrary bytes, so callers of `list_archive_files` / `uncompress_archive` / `ArchiveIterator` couldn't distinguish real archives from plain files — it would yield a single entry called `data`. This PR stops registering the raw handler on the archive code paths and bumps the crate to 0.16.0 for the breaking change.
- Commit 1 (`feat!: require real archives on archive entry points`) removes the raw handler registration across `list_archive_files`, `list_archive_entries`, `uncompress_archive`, `uncompress_archive_file`, `ArchiveIterator` (and their `_with_encoding` and async variants). `uncompress_data` is unchanged — handling raw compressed streams is its purpose. Adds `ArchiveIteratorBuilder::raw_format(true)` as an opt-in escape hatch for callers that relied on the old permissive behavior.
- Commit 2 (`feat: expose ArchiveIteratorBuilder::mtree_format opt-out`) adds a matching opt-*out* for the mtree half. libarchive's mtree handler also matches free-form text (a plain gunzip'd text file is enough), but it remains registered by default to preserve libarchive's behavior on the top-level entry points. Strict callers iterating with `ArchiveIterator` can pass `.mtree_format(false)` to reject entries whose format base mask indicates mtree. Exposes `archive_format` + `ARCHIVE_FORMAT_BASE_MASK` + `ARCHIVE_FORMAT_MTREE` in the FFI bindings (and the `generate-ffi` script so regeneration stays in sync).

## Test plan
- [x] `cargo test --features tokio_support,futures_support,async_support` — 62 integration + 14 doctests pass
- [x] `cargo clippy --features tokio_support,futures_support,async_support --tests -- -D warnings` clean
- [x] `cargo test --test disk_full_test` passes
- [x] Regression tests cover both halves: `list_archive_files_rejects_non_archive_bytes`, `uncompress_archive_rejects_non_archive_bytes`, `iterator_default_rejects_non_archive_bytes`, `iterator_raw_format_opt_in_accepts_non_archive_bytes`, `iterator_mtree_format_opt_out_rejects_gzip_text`
- [ ] CI status checks (all 5 required checks run on this branch)