### PR TITLE
chore(nix): migrate flake to red-tape and bump nixpkgs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,17 @@
 
 ## [Unreleased] - ReleaseDate
 
+* flake: migrate from `flake-utils` to `red-tape`, bump nixpkgs from
+  `nixos-24.05` to `nixos-25.11`, read the MSRV channel from `Cargo.toml` via
+  `lib.importTOML`, and add the missing `xz`, `bzip2`, `zlib`, `libxml2`, and
+  `openssl` pkg-config dependencies so `cargo check --all-features` (the
+  `static` feature) builds in the devshell [#164]
+* docs.rs: drop the `static` feature from rendered docs so the crate's
+  docs.rs build stops failing on the `libb2` pkg-config probe (the
+  `static_*` features have no public API surface) [#164]
+
+[#164]: https://github.com/OSSystems/compress-tools-rs/pull/164
+
 ## [0.16.0] - 2026-04-23
 
 * **Breaking:** libarchive's "raw" format handler is no longer registered on

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ build = "src/build.rs"
 rust-version = "1.82.0"
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["futures_support", "tokio_support"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [package.metadata.playground]

--- a/devshell.nix
+++ b/devshell.nix
@@ -1,0 +1,38 @@
+{ pkgs, lib, inputs, system, ... }:
+
+let
+  rust-toolchain = with inputs.rust.packages.${system};
+    let
+      msrvToolchain = toolchainOf {
+        channel = (lib.importTOML ./Cargo.toml).package.rust-version;
+        sha256 = "sha256-yMuSb5eQPO/bHv+Bcf/US8LVMbf/G/0MSfiPwBhiPpk=";
+      };
+    in
+    combine [
+      (msrvToolchain.withComponents [ "rustc" "cargo" "rust-src" "clippy" ])
+
+      latest.rustfmt
+      latest.rust-analyzer
+    ];
+in
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    rust-toolchain
+    rust-bindgen
+    pkg-config
+    libarchive
+    # Required by the `static` feature (build.rs probes these via
+    # pkg-config when libarchive is linked statically).
+    libb2
+    lz4
+    zstd
+    clang
+    llvmPackages.libclang
+
+    cargo-release
+  ];
+
+  shellHook = ''
+    export LIBCLANG_PATH="${pkgs.llvmPackages.libclang}/lib";
+  '';
+}

--- a/devshell.nix
+++ b/devshell.nix
@@ -26,6 +26,11 @@ pkgs.mkShell {
     libb2
     lz4
     zstd
+    xz
+    bzip2
+    zlib
+    libxml2
+    openssl
     clang
     llvmPackages.libclang
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,42 +1,78 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
+    "adios": {
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "lastModified": 1772186395,
+        "narHash": "sha256-NshyMZYZwjKMLKEX0eDf9Fcekq8MFNFk02wW5knzlZU=",
+        "owner": "adisbladis",
+        "repo": "adios",
+        "rev": "6a54071689ec9ec784a16e4eec8ddb864eca2982",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "adisbladis",
+        "repo": "adios",
+        "type": "github"
+      }
+    },
+    "adios-flake": {
+      "inputs": {
+        "adios": "adios"
+      },
+      "locked": {
+        "lastModified": 1772646328,
+        "narHash": "sha256-0xwNbjvHON8LqhIx5VMPZpR1B5Unq/7BH6tktELwRyA=",
+        "owner": "Mic92",
+        "repo": "adios-flake",
+        "rev": "6082a7bf428fe6c29b80c8ef4582ffce46cfea77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "adios-flake",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719145550,
-        "narHash": "sha256-K0i/coxxTEl30tgt4oALaylQfxqbotTSNb1/+g+mKMQ=",
+        "lastModified": 1776734388,
+        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e4509b3a560c87a8d4cb6f9992b8915abf9e36d8",
+        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-24.05",
+        "ref": "nixos-25.11",
         "type": "indirect"
+      }
+    },
+    "red-tape": {
+      "inputs": {
+        "adios-flake": "adios-flake",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774285314,
+        "narHash": "sha256-ad5J3MsK11stsDfR0no6zr6K/c7Rr8HCQFpVw1ixmLA=",
+        "owner": "phaer",
+        "repo": "red-tape",
+        "rev": "5ad2da408cc59621dfedd2d9256e0b6c082256c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phaer",
+        "repo": "red-tape",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "red-tape": "red-tape",
         "rust": "rust"
       }
     },
@@ -48,11 +84,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1719210510,
-        "narHash": "sha256-k2UzQJoYURRxcSZxseB6ZX/cdr0K4svGDBZiE9FkaYs=",
+        "lastModified": 1776931971,
+        "narHash": "sha256-3ZcWjBpZKsiWT0X9CSa6zG+Zk4ZRAmh56KYrm2iRqKU=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "57a65e7ae468a2d53f645afdd84fcc3f1c63a5d7",
+        "rev": "5b3016c5f8cdd37d5e557646d369ce76e30666de",
         "type": "github"
       },
       "original": {
@@ -64,32 +100,17 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1719057472,
-        "narHash": "sha256-jzZRTQjXhiwEdzo/SlxP72BUa7g0LVr7MEsaR7A/geg=",
+        "lastModified": 1776800521,
+        "narHash": "sha256-f8YJfwAOsLFpIoqZuX3yF69UvMLrkx7iVzMH1pJU7cM=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "2fd803cc13dc11aeacaa6474e3f803988a7bfe1a",
+        "rev": "8954b66d43225e62c92e8bbcc8500191b5cceb1e",
         "type": "github"
       },
       "original": {
         "owner": "rust-lang",
         "ref": "nightly",
         "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,11 @@
   description = "compress-tools-rs";
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-24.05";
-    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "nixpkgs/nixos-25.11";
+    red-tape = {
+      url = "github:phaer/red-tape";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     rust = {
       url = "github:nix-community/fenix";
@@ -11,47 +14,8 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-
-        rust-toolchain = with rust.packages.${system};
-          let
-            msrvToolchain = toolchainOf {
-              channel = "1.82.0";
-              sha256 = "sha256-yMuSb5eQPO/bHv+Bcf/US8LVMbf/G/0MSfiPwBhiPpk=";
-            };
-          in
-          combine [
-            (msrvToolchain.withComponents [ "rustc" "cargo" "rust-src" "clippy" ])
-
-            latest.rustfmt
-            latest.rust-analyzer
-          ];
-      in
-      {
-        devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            rust-toolchain
-            rust-bindgen
-            pkg-config
-            libarchive
-            # Required by the `static` feature (build.rs probes these via
-            # pkg-config when libarchive is linked statically).
-            libb2
-            lz4
-            zstd
-            clang
-            llvmPackages.libclang
-
-            cargo-release
-          ];
-
-          # why do we need to set the library path manually?
-          shellHook = ''
-            export LIBCLANG_PATH="${pkgs.llvmPackages.libclang}/lib";
-          '';
-        };
-      });
+  outputs = inputs: inputs.red-tape.mkFlake {
+    inherit inputs;
+    src = ./.;
+  };
 }


### PR DESCRIPTION
## Summary

- Migrate the flake from `flake-utils` to `phaer/red-tape` (a filesystem-convention flake builder). The devShell now lives in `devshell.nix` and is auto-wired by red-tape; `flake.nix` is down to a one-liner that delegates to `red-tape.mkFlake`.
- Bump `nixpkgs` from `nixos-24.05` to `nixos-25.11` and refresh `fenix` / `rust-analyzer` lock entries. Pin `red-tape.inputs.nixpkgs` to follow root so only one nixpkgs tree is evaluated.
- Read the MSRV channel from `Cargo.toml` via `lib.importTOML` so the fenix toolchain stays in sync with `package.rust-version`.
- Add `xz`, `bzip2`, `zlib`, `libxml2`, and `openssl` to the devShell so `cargo check --all-features` (which turns on the `static` meta-feature) builds out of the box in the shell.
- Fix docs.rs rendering for 0.16.0 (`doc_status: false`): `[package.metadata.docs.rs] all-features = true` was activating `static`, which made `build.rs` probe `libb2` — not present in the docs.rs `crates-build-env`. Narrow to `features = ["futures_support", "tokio_support"]`; the `static_*` features have no public API surface so docs lose nothing.

## Test plan

- [x] `nix flake show` lists `devShells.${system}.default`
- [x] `nix develop` enters the shell; reports `rustc 1.82.0`, `cargo 1.82.0`, `libarchive 3.8.6`
- [x] `cargo check` (default features) passes inside the devshell
- [x] `cargo check --all-features` passes inside the devshell
- [x] `cargo test --lib` passes
- [x] `cargo doc --no-deps --features futures_support,tokio_support` renders cleanly (mirrors the new docs.rs invocation)
- [ ] docs.rs successfully renders the next release after this lands